### PR TITLE
Fix state assumption bug

### DIFF
--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -51,6 +51,12 @@ class Alarm:
             self._handle_system_status_event(event)
 
     def _handle_arming_update(self, update: ArmingUpdate) -> None:
+        """
+        Normal: []
+        Exit Delay: [<ArmingStatus.MANUAL_EXCLUDE_MODE: 256>]
+        Armed: [<ArmingStatus.MANUAL_EXCLUDE_MODE: 256>, <ArmingStatus.DAY_ZONE_SELECT: 1024>]
+        
+        """
         if ArmingUpdate.ArmingStatus.AREA_1_ARMED in update.status:
             return self._update_arming_state(ArmingState.ARMED)
         elif ArmingUpdate.ArmingStatus.ENTRY_DELAY_1_ON in update.status:

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -53,7 +53,12 @@ class Alarm:
     def _handle_arming_update(self, update: ArmingUpdate) -> None:
         if ArmingUpdate.ArmingStatus.AREA_1_ARMED in update.status:
             return self._update_arming_state(ArmingState.ARMED)
-        else:
+        elif ArmingUpdate.ArmingStatus.ENTRY_DELAY_1_ON in update.status:
+            return self._update_arming_state(ArmingState.ENTRY_DELAY)
+        elif self.arming_state is ArmingState.UNKNOWN:
+            # TODO(NW): Initially update to disarmed when the state is unknown.
+            # In the future, it would be ideal to infer other states by making
+            # calls to other status commands (i.e. zones in delay).
             return self._update_arming_state(ArmingState.DISARMED)
 
     def _handle_zone_input_update(self, update: ZoneUpdate) -> None:

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Callable, List
 
-from .event import BaseEvent, ZoneUpdate, ArmingUpdate, SystemStatusEvent
+from .event import BaseEvent, ZoneUpdate, SystemStatusEvent
 
 
 class ArmingState(Enum):
@@ -35,37 +35,20 @@ class Alarm:
         triggered: Optional[bool]
 
     def __init__(self) -> None:
-        self.arming_state: ArmingState = ArmingState.UNKNOWN
+        # TODO: Determine the best way to query the alarm initial state. For
+        #  now, we assume the alarm is initially disarmed on connection.
+        self.arming_state: ArmingState = ArmingState.DISARMED
         self.zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(16)]
 
         self._on_state_change: Optional[Callable[['ArmingState'], None]] = None
         self._on_zone_change: Optional[Callable[[int, bool], None]] = None
 
     def handle_event(self, event: BaseEvent) -> None:
-        if isinstance(event, ArmingUpdate):
-            self._handle_arming_update(event)
-        elif (isinstance(event, ZoneUpdate)
-              and event.request_id == ZoneUpdate.RequestID.ZONE_INPUT_UNSEALED):
+        if (isinstance(event, ZoneUpdate)
+                and event.request_id == ZoneUpdate.RequestID.ZONE_INPUT_UNSEALED):
             self._handle_zone_input_update(event)
         elif isinstance(event, SystemStatusEvent):
             self._handle_system_status_event(event)
-
-    def _handle_arming_update(self, update: ArmingUpdate) -> None:
-        """
-        Normal: []
-        Exit Delay: [<ArmingStatus.MANUAL_EXCLUDE_MODE: 256>]
-        Armed: [<ArmingStatus.MANUAL_EXCLUDE_MODE: 256>, <ArmingStatus.DAY_ZONE_SELECT: 1024>]
-        
-        """
-        if ArmingUpdate.ArmingStatus.AREA_1_ARMED in update.status:
-            return self._update_arming_state(ArmingState.ARMED)
-        elif ArmingUpdate.ArmingStatus.ENTRY_DELAY_1_ON in update.status:
-            return self._update_arming_state(ArmingState.ENTRY_DELAY)
-        elif self.arming_state is ArmingState.UNKNOWN:
-            # TODO(NW): Initially update to disarmed when the state is unknown.
-            # In the future, it would be ideal to infer other states by making
-            # calls to other status commands (i.e. zones in delay).
-            return self._update_arming_state(ArmingState.DISARMED)
 
     def _handle_zone_input_update(self, update: ZoneUpdate) -> None:
         for i, zone in enumerate(self.zones):

--- a/nessclient/cli/server/alarm_server.py
+++ b/nessclient/cli/server/alarm_server.py
@@ -142,10 +142,8 @@ def get_events_for_state_update(
 
 def get_arming_status(state: Alarm.ArmingState) -> List[ArmingUpdate.ArmingStatus]:
     # TODO(NW): Verify these are the correct response values for different alarm states.
-    if state == Alarm.ArmingState.EXIT_DELAY:
+    if state == Alarm.ArmingState.ARMED_AWAY:
         return [ArmingUpdate.ArmingStatus.AREA_1_ARMED]
-    elif state == Alarm.ArmingState.ARMED_AWAY:
-        return [ArmingUpdate.ArmingStatus.AREA_1_FULLY_ARMED]
     elif state == Alarm.ArmingState.ENTRY_DELAY:
         return [ArmingUpdate.ArmingStatus.ENTRY_DELAY_1_ON]
     return []

--- a/nessclient/cli/server/alarm_server.py
+++ b/nessclient/cli/server/alarm_server.py
@@ -141,11 +141,11 @@ def get_events_for_state_update(
 
 
 def get_arming_status(state: Alarm.ArmingState) -> List[ArmingUpdate.ArmingStatus]:
-    # TODO(NW): Verify these are the correct response values for different alarm states.
     if state == Alarm.ArmingState.ARMED_AWAY:
-        return [ArmingUpdate.ArmingStatus.AREA_1_ARMED]
-    elif state == Alarm.ArmingState.ENTRY_DELAY:
-        return [ArmingUpdate.ArmingStatus.ENTRY_DELAY_1_ON]
+        return [
+            ArmingUpdate.ArmingStatus.MANUAL_EXCLUDE_MODE,
+            ArmingUpdate.ArmingStatus.DAY_ZONE_SELECT
+        ]
     return []
 
 

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -59,12 +59,10 @@ class Client:
         return await self.send_command(command)
 
     async def update(self) -> None:
-        """Force update of alarm status and zones"""
+        """Force update of zones"""
         await asyncio.gather(
             # List unsealed Zones
             self.send_command('S00'),
-            # Arming status update
-            self.send_command('S14'),
         )
 
     async def _connect(self) -> None:
@@ -132,7 +130,7 @@ class Client:
         await asyncio.sleep(self._update_interval)
         while not self._closed:
             _LOGGER.debug("Forcing a keepalive state update")
-            await self.send_command('S00')
+            await self.update()
             await asyncio.sleep(self._update_interval)
 
     async def keepalive(self) -> None:

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -132,7 +132,7 @@ class Client:
         await asyncio.sleep(self._update_interval)
         while not self._closed:
             _LOGGER.debug("Forcing a keepalive state update")
-            await self.update()
+            await self.send_command('S00')
             await asyncio.sleep(self._update_interval)
 
     async def keepalive(self) -> None:


### PR DESCRIPTION
`ArmingUpdate` queries are not able to accurately determine the state of the alarm system, and cause issues when refreshing the state. For example, the alarm is put into exit delay, and nessclient knows this, but this state is wiped away as soon as the state is refreshed via a `S14` (`ArmingUpdate`) command. 

In the future, if this is required, then we should find a better way to find the alarm state on-demand. For now, we assume the alarm is in a disarmed state on connect.