### PR TITLE
Handle 60th minute ness bug

### DIFF
--- a/nessclient/packet.py
+++ b/nessclient/packet.py
@@ -184,4 +184,22 @@ def is_user_interface_resp(start: int) -> bool:
 
 
 def decode_timestamp(data: str) -> datetime.datetime:
-    return datetime.datetime.strptime(data, '%y%m%d%H%M%S')
+    """
+    Decode timestamp using bespoke decoder.
+    Cannot use simple strptime since the ness panel contains a bug
+    that P199E zone and state updates emitted on the hour cause a minute
+    value of `60` to be sent, causing strptime to fail. This decoder handles
+    this edge case.
+    """
+    year = 2000 + int(data[0:2])
+    month = int(data[2:4])
+    day = int(data[4:6])
+    hour = int(data[6:8])
+    minute = int(data[8:10])
+    second = int(data[10:12])
+    if minute == 60:
+        minute = 0
+        hour += 1
+
+    return datetime.datetime(year=year, month=month, day=day, hour=hour,
+                             minute=minute, second=second)

--- a/nessclient_tests/test_packet.py
+++ b/nessclient_tests/test_packet.py
@@ -120,3 +120,14 @@ class PacketTestCase(unittest.TestCase):
         self.assertEqual(pkt.data, '070000')
         self.assertIsNone(pkt.timestamp)
         # self.assertEqual(pkt.checksum, 0x14)
+
+    def test_bad_timestamp(self):
+        pkt = Packet.decode('8700036100070019022517600057')
+        self.assertEqual(pkt.start, 0x87)
+        self.assertEqual(pkt.address, 0x00)
+        self.assertEqual(pkt.length, 3)
+        self.assertEqual(pkt.seq, 0x00)
+        self.assertEqual(pkt.command, CommandType.SYSTEM_STATUS)
+        self.assertEqual(pkt.data, '000700')
+        self.assertEqual(pkt.timestamp, datetime.datetime(
+            year=2019, month=2, day=25, hour=18, minute=0, second=0))


### PR DESCRIPTION
Decode timestamp using bespoke decoder.

Cannot use simple strptime since the ness panel contains a bug that P199E zone and state updates emitted on the hour cause a minute value of `60` to be sent, causing strptime to fail. This decoder handles this edge case.

```
2019-02-25 18:01:28 DEBUG (MainThread) [nessclient.client] Decoding data: '8700836101070019022517595687'
2019-02-25 18:01:28 DEBUG (MainThread) [nessclient.packet] Decoding bytes: '8700836101070019022517595687'
2019-02-25 18:01:32 DEBUG (MainThread) [nessclient.client] Decoding data: '8700036100070019022517600057'
2019-02-25 18:01:32 DEBUG (MainThread) [nessclient.packet] Decoding bytes: '8700036100070019022517600057'
2019-02-25 18:01:32 ERROR (MainThread) [homeassistant.core] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/config/deps/lib/python3.7/site-packages/nessclient/client.py", line 141, in keepalive
    self._update_loop(),
  File "/config/deps/lib/python3.7/site-packages/nessclient/client.py", line 118, in _recv_loop
    pkt = Packet.decode(decoded_data)
  File "/config/deps/lib/python3.7/site-packages/nessclient/packet.py", line 120, in decode
    timestamp = decode_timestamp(data.take_bytes(6))
  File "/config/deps/lib/python3.7/site-packages/nessclient/packet.py", line 180, in decode_timestamp
    return datetime.datetime.strptime(data, '%y%m%d%H%M%S')
  File "/usr/local/lib/python3.7/_strptime.py", line 577, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/usr/local/lib/python3.7/_strptime.py", line 362, in _strptime
    data_string[found.end():])
ValueError: unconverted data remains: 0
```