### PR TITLE
Handle newer user interface responses

### DIFF
--- a/nessclient_tests/test_packet.py
+++ b/nessclient_tests/test_packet.py
@@ -3,6 +3,7 @@ import logging
 import unittest
 from os import path
 
+from nessclient import BaseEvent
 from nessclient.packet import Packet, CommandType
 
 _LOGGER = logging.getLogger(__name__)
@@ -142,3 +143,9 @@ class PacketTestCase(unittest.TestCase):
         self.assertEqual(pkt.data, '001600')
         self.assertEqual(pkt.timestamp, datetime.datetime(
             year=2019, month=2, day=28, hour=23, minute=3, second=22))
+
+    def test_decode_update(self):
+        pkt = Packet.decode('820003601700867e')
+        event = BaseEvent.decode(pkt)
+        print(pkt)
+        print(event)


### PR DESCRIPTION
Implements the fix for #34

Adds two new user interface response types - panel version and aux outputs status found in newer panel version and newer documentation. 