### PR TITLE
Add option to infer arming state

### DIFF
--- a/nessclient/cli/events.py
+++ b/nessclient/cli/events.py
@@ -9,9 +9,13 @@ from ..event import BaseEvent
 @click.command(help='Listen for emitted alarm events')
 @click.option('--host', required=True)
 @click.option('--port', required=True, type=int)
-def events(host: str, port: int):
+@click.option('--update-interval', type=int, default=60)
+@click.option('--infer-arming-state/--no-infer-arming-state')
+def events(host: str, port: int, update_interval: int, infer_arming_state: bool):
     loop = asyncio.get_event_loop()
-    client = Client(host=host, port=port, loop=loop)
+    client = Client(host=host, port=port, loop=loop,
+                    infer_arming_state=infer_arming_state,
+                    update_interval=update_interval)
 
     @client.on_zone_change
     def on_zone_change(zone: int, triggered: bool):

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -15,6 +15,13 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Client:
+    """
+    :param update_interval: Frequency (in seconds) to trigger a full state
+        refresh
+    :param infer_arming_state: Infer the `DISARMED` arming state only via
+        system status events. This works around a bug with some panels
+        (`<v5.8`) which emit `update.status = []` when they are armed.
+    """
     def __init__(self,
                  connection: Optional[Connection] = None,
                  host: Optional[str] = None,
@@ -23,13 +30,6 @@ class Client:
                  update_interval: int = 60,
                  infer_arming_state: bool = False,
                  alarm: Optional[Alarm] = None):
-        """
-        :param update_interval: Frequency in seconds to trigger a full state
-        refresh
-        :param infer_arming_state: Infer the DISARMED arming state only via
-        system status events. This works around a bug with some panels (<v5.8)
-        which emit update.status = [] when they are armed.
-        """
         if connection is None:
             assert host is not None
             assert port is not None

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -21,7 +21,15 @@ class Client:
                  port: Optional[int] = None,
                  loop: Optional[asyncio.AbstractEventLoop] = None,
                  update_interval: int = 60,
+                 infer_arming_state: bool = False,
                  alarm: Optional[Alarm] = None):
+        """
+        :param update_interval: Frequency in seconds to trigger a full state
+        refresh
+        :param infer_arming_state: Infer the DISARMED arming state only via
+        system status events. This works around a bug with some panels (<v5.8)
+        which emit update.status = [] when they are armed.
+        """
         if connection is None:
             assert host is not None
             assert port is not None
@@ -29,7 +37,7 @@ class Client:
             connection = IP232Connection(host=host, port=port, loop=loop)
 
         if alarm is None:
-            alarm = Alarm()
+            alarm = Alarm(infer_arming_state=infer_arming_state)
 
         self.alarm = alarm
         self._on_event_received: Optional[Callable[[BaseEvent], None]] = None

--- a/nessclient_tests/test_alarm.py
+++ b/nessclient_tests/test_alarm.py
@@ -87,6 +87,29 @@ def test_handle_event_arming_update_disarmed(alarm):
     assert alarm.arming_state == ArmingState.DISARMED
 
 
+def test_handle_event_arming_update_infer_arming_state_armed_empty():
+    alarm = Alarm(infer_arming_state=True)
+    alarm.arming_state = ArmingState.ARMED
+    event = ArmingUpdate(status=[], address=None, timestamp=None)
+    alarm.handle_event(event)
+    assert alarm.arming_state == ArmingState.ARMED
+
+
+def test_handle_event_arming_update_without_infer_arming_state_armed_empty():
+    alarm = Alarm(infer_arming_state=False)
+    alarm.arming_state = ArmingState.ARMED
+    event = ArmingUpdate(status=[], address=None, timestamp=None)
+    alarm.handle_event(event)
+    assert alarm.arming_state == ArmingState.DISARMED
+
+
+def test_handle_event_arming_update_infer_arming_state_unknown_empty():
+    alarm = Alarm(infer_arming_state=True)
+    event = ArmingUpdate(status=[], address=None, timestamp=None)
+    alarm.handle_event(event)
+    assert alarm.arming_state == ArmingState.DISARMED
+
+
 def test_handle_event_arming_update_callback(alarm):
     cb = Mock()
     alarm.on_state_change(cb)


### PR DESCRIPTION
A potential solution to #33. Adds back the inference functionality that existed before `#23` which removed it:

```diff
     def _handle_arming_update(self, update: ArmingUpdate) -> None:
-        if update.status == [ArmingUpdate.ArmingStatus.MANUAL_EXCLUDE_MODE]:
+        if update.status == [ArmingUpdate.ArmingStatus.AREA_1_ARMED]:
             return self._update_arming_state(ArmingState.EXIT_DELAY)
-        if ArmingUpdate.ArmingStatus.MANUAL_EXCLUDE_MODE in update.status and \
-                ArmingUpdate.ArmingStatus.DAY_ZONE_SELECT:
-            # TODO(NW): This might not be the correct condition for an "armed"
-            #  system, in fact, the same states are shown throughout armed, and
-            #  entry delay. We should determine a better way to query the
-            #  current alarm state.
+        if ArmingUpdate.ArmingStatus.AREA_1_ARMED in update.status and \
+                ArmingUpdate.ArmingStatus.AREA_1_FULLY_ARMED in update.status:
             return self._update_arming_state(ArmingState.ARMED)
-        elif self.arming_state == ArmingState.UNKNOWN:
-            # TODO(NW): Initially update to disarmed when the state is unknown.
-            #  In the future, it would be ideal to infer other states by making
-            #  calls to other status commands (i.e. zones in delay).
+        else:
             return self._update_arming_state(ArmingState.DISARMED)

```

I have put this configuration option behind a flag as it could introduce buginess for currently working setups (like my own). There is potential for setups to now get stuck/report an `ARMED` or `ARMING` state and never return to `DISARMED` if the panel never emits a system status event declaring the panel is disarmed.

If this solution proves to be successful and applies to particular panel versions (i.e. `<5.8`), then I can introduce a version check at startup and have this functionality auto-configured to avoid needless setup to get a working system. This would use the newly added #36 functionality.