### PR TITLE
Wrap connection writing with a lock

### DIFF
--- a/nessclient/connection.py
+++ b/nessclient/connection.py
@@ -38,6 +38,7 @@ class IP232Connection(Connection):
                  loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()):
         super().__init__()
 
+        self._write_lock = asyncio.Lock(loop=loop)
         self._host = host
         self._port = port
         self._loop = loop
@@ -79,10 +80,11 @@ class IP232Connection(Connection):
         return data.strip()
 
     async def write(self, data: bytes) -> None:
-        assert self._writer is not None
+        async with self._write_lock:
+            assert self._writer is not None
 
-        self._writer.write(data)
-        await self._writer.drain()
+            self._writer.write(data)
+            await self._writer.drain()
 
     async def close(self) -> None:
         if self.connected and self._writer is not None:

--- a/nessclient/connection.py
+++ b/nessclient/connection.py
@@ -80,11 +80,14 @@ class IP232Connection(Connection):
         return data.strip()
 
     async def write(self, data: bytes) -> None:
+        _LOGGER.debug("Waiting for write_lock to write data: %s", data)
         async with self._write_lock:
+            _LOGGER.debug("Obtained write_lock to write data: %s", data)
             assert self._writer is not None
 
             self._writer.write(data)
             await self._writer.drain()
+            _LOGGER.debug("Data was written: %s", data)
 
     async def close(self) -> None:
         if self.connected and self._writer is not None:


### PR DESCRIPTION
I suspect there might be an issue with interleaved writes as last night @cryptelli mentioned that he was having an issue with a short `update_interval` (`2s`) meant that he needed to send the arm command up to 3 times to get the alarm to arm.

I have wrapped the network writes in a lock to see if this solves the problem.