### PR TITLE
Fully remove `loop` argument

### DIFF
--- a/examples/listening_for_events.py
+++ b/examples/listening_for_events.py
@@ -5,7 +5,7 @@ from nessclient import Client, ArmingState, BaseEvent
 loop = asyncio.get_event_loop()
 host = '127.0.0.1'
 port = 65432
-client = Client(host=host, port=port, loop=loop)
+client = Client(host=host, port=port)
 
 
 @client.on_zone_change

--- a/examples/sending_commands.py
+++ b/examples/sending_commands.py
@@ -5,7 +5,7 @@ from nessclient import Client
 loop = asyncio.get_event_loop()
 host = '127.0.0.1'
 port = 65432
-client = Client(host=host, port=port, loop=loop)
+client = Client(host=host, port=port)
 
 # Send arming command via library abstraction
 loop.run_until_complete(client.arm_away('1234'))

--- a/nessclient/cli/events.py
+++ b/nessclient/cli/events.py
@@ -13,7 +13,7 @@ from ..event import BaseEvent
 @click.option('--infer-arming-state/--no-infer-arming-state')
 def events(host: str, port: int, update_interval: int, infer_arming_state: bool) -> None:
     loop = asyncio.get_event_loop()
-    client = Client(host=host, port=port, loop=loop,
+    client = Client(host=host, port=port,
                     infer_arming_state=infer_arming_state,
                     update_interval=update_interval)
 

--- a/nessclient/cli/send_command.py
+++ b/nessclient/cli/send_command.py
@@ -11,7 +11,7 @@ from ..client import Client
 @click.argument('command')
 def send_command(host: str, port: int, command: str) -> None:
     loop = asyncio.get_event_loop()
-    client = Client(host=host, port=port, loop=loop)
+    client = Client(host=host, port=port)
 
     loop.run_until_complete(client.send_command(command))
     loop.run_until_complete(client.close())

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -26,15 +26,13 @@ class Client:
                  connection: Optional[Connection] = None,
                  host: Optional[str] = None,
                  port: Optional[int] = None,
-                 loop: Optional[asyncio.AbstractEventLoop] = None,
                  update_interval: int = 60,
                  infer_arming_state: bool = False,
                  alarm: Optional[Alarm] = None):
         if connection is None:
             assert host is not None
             assert port is not None
-            assert loop is not None
-            connection = IP232Connection(host=host, port=port, loop=loop)
+            connection = IP232Connection(host=host, port=port)
 
         if alarm is None:
             alarm = Alarm(infer_arming_state=infer_arming_state)

--- a/nessclient/connection.py
+++ b/nessclient/connection.py
@@ -34,14 +34,12 @@ class Connection(ABC):
 class IP232Connection(Connection):
     """A connection via IP232 with a Ness D8X/D16X server"""
 
-    def __init__(self, host: str, port: int,
-                 loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()):
+    def __init__(self, host: str, port: int):
         super().__init__()
 
-        self._write_lock = asyncio.Lock(loop=loop)
+        self._write_lock = asyncio.Lock()
         self._host = host
         self._port = port
-        self._loop = loop
         self._reader: Optional[asyncio.StreamReader] = None
         self._writer: Optional[asyncio.StreamWriter] = None
 


### PR DESCRIPTION
https://github.com/nickw444/nessclient/pull/43 partially removed passing `loop` to various asyncio functions/classes. This PR completes the change.

> From the sounds of thing having a user-provided `loop` might now be unnecessary anyway, so removal of the constructor arg sounds like the trivial way forward:
>
> https://stackoverflow.com/a/60315290