### PR TITLE
suppress Failed to decode packet warning for Dplus 8/16 panels

### DIFF
--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -28,7 +28,6 @@ class Client:
         connection: Optional[Connection] = None,
         host: Optional[str] = None,
         port: Optional[int] = None,
-        name: Optional[str] = "Alarm Panel",
         serial_tty: Optional[str] = None,
         update_interval: int = 60,
         infer_arming_state: bool = False,
@@ -48,7 +47,6 @@ class Client:
             alarm = Alarm(infer_arming_state=infer_arming_state)
 
         self.alarm = alarm
-        self.name = name
         self._on_event_received: Optional[Callable[[BaseEvent], None]] = None
         self._connection = connection
         self._closed = False

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -28,6 +28,7 @@ class Client:
         connection: Optional[Connection] = None,
         host: Optional[str] = None,
         port: Optional[int] = None,
+        name: Optional[str] = "Alarm Panel",
         serial_tty: Optional[str] = None,
         update_interval: int = 60,
         infer_arming_state: bool = False,
@@ -47,6 +48,7 @@ class Client:
             alarm = Alarm(infer_arming_state=infer_arming_state)
 
         self.alarm = alarm
+        self.name = name
         self._on_event_received: Optional[Callable[[BaseEvent], None]] = None
         self._connection = connection
         self._closed = False

--- a/nessclient/event.py
+++ b/nessclient/event.py
@@ -146,6 +146,7 @@ class StatusUpdate(BaseEvent):
         VIEW_STATE = 0x16
         PANEL_VERSION = 0x17
         AUXILIARY_OUTPUTS = 0x18
+        UNKNOWN = 0x30
 
     def __init__(
         self,
@@ -173,6 +174,8 @@ class StatusUpdate(BaseEvent):
             return PanelVersionUpdate.decode(packet)
         elif request_id == StatusUpdate.RequestID.AUXILIARY_OUTPUTS:
             return AuxiliaryOutputsUpdate.decode(packet)
+        elif request_id == StatusUpdate.RequestID.UNKNOWN:
+            return None
         else:
             raise ValueError("Unhandled request_id case: {}".format(request_id))
 

--- a/nessclient/event.py
+++ b/nessclient/event.py
@@ -146,7 +146,7 @@ class StatusUpdate(BaseEvent):
         VIEW_STATE = 0x16
         PANEL_VERSION = 0x17
         AUXILIARY_OUTPUTS = 0x18
-        UNKNOWN = 0x30
+        UNDOCUMENTED_01 = 0x30
 
     def __init__(
         self,
@@ -174,7 +174,7 @@ class StatusUpdate(BaseEvent):
             return PanelVersionUpdate.decode(packet)
         elif request_id == StatusUpdate.RequestID.AUXILIARY_OUTPUTS:
             return AuxiliaryOutputsUpdate.decode(packet)
-        elif request_id == StatusUpdate.RequestID.UNKNOWN:
+        elif request_id == StatusUpdate.RequestID.UNDOCUMENTED_01:
             return None
         else:
             raise ValueError("Unhandled request_id case: {}".format(request_id))

--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -82,6 +82,13 @@ class StatusUpdateTestCase(unittest.TestCase):
         pkt = make_packet(CommandType.USER_INTERFACE, "550000")
         self.assertRaises(ValueError, lambda: StatusUpdate.decode(pkt))
 
+    def test_decode_undocumented_event(self):
+        pkt = make_packet(CommandType.USER_INTERFACE, "300000")
+        event = StatusUpdate.decode(pkt)
+        self.assertIsNone(event)
+
+
+
 
 class ArmingUpdateTestCase(unittest.TestCase):
     def test_encode(self):

--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -87,9 +87,6 @@ class StatusUpdateTestCase(unittest.TestCase):
         event = StatusUpdate.decode(pkt)
         self.assertIsNone(event)
 
-
-
-
 class ArmingUpdateTestCase(unittest.TestCase):
     def test_encode(self):
         event = ArmingUpdate(


### PR DESCRIPTION
Changes: 

~~--- in preparation for moving to a GUI setup from home assistant, and also allowing multiple panels to be supported, allow an instance of the ness client to hold a name. By default, this will be "Alarm Panel", to not break backwards compatibility ---~~

- suppress suppress Failed to decode packet warning for Dplus 8/16 panels