### PR TITLE
Expand panel version mapping

### DIFF
--- a/nessclient/event.py
+++ b/nessclient/event.py
@@ -429,9 +429,24 @@ class ViewStateUpdate(StatusUpdate):
 
 class PanelVersionUpdate(StatusUpdate):
     class Model(Enum):
-        D16X = 0x00
-        D16X_3G = 0x04
-        D16XCEL = 0x14
+        """Panel model and modem combinations.
+
+        These values are hard coded from the panel documentation where the
+        upper four bits represent the panel model and the lower four bits the
+        modem (if any). The values are not generated dynamically so that only
+        known combinations are accepted.
+        """
+
+        # Base D8X panel variants
+        D8X = 0x00
+        D8X_CEL_3G = 0x04
+        D8X_CEL_4G = 0x05
+        D32X = 0x06
+
+        # D16X based panels
+        D16X = 0x10
+        D16X_CEL_3G = 0x14
+        D16X_CEL_4G = 0x15
 
     def __init__(
         self,

--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -224,23 +224,33 @@ class SystemStatusEventTestCase(unittest.TestCase):
 
 
 class PanelVersionUpdateTestCase(unittest.TestCase):
-    def test_model(self):
-        pkt = make_packet(CommandType.USER_INTERFACE, "160000")
+    def test_d8x_model(self):
+        pkt = make_packet(CommandType.USER_INTERFACE, "170000")
+        event = PanelVersionUpdate.decode(pkt)
+        self.assertEqual(event.model, PanelVersionUpdate.Model.D8X)
+
+    def test_d8xcel_3g_model(self):
+        pkt = make_packet(CommandType.USER_INTERFACE, "170400")
+        event = PanelVersionUpdate.decode(pkt)
+        self.assertEqual(event.model, PanelVersionUpdate.Model.D8X_CEL_3G)
+
+    def test_d16x_model(self):
+        pkt = make_packet(CommandType.USER_INTERFACE, "171000")
         event = PanelVersionUpdate.decode(pkt)
         self.assertEqual(event.model, PanelVersionUpdate.Model.D16X)
 
-    def test_3g_model(self):
-        pkt = make_packet(CommandType.USER_INTERFACE, "160400")
+    def test_d16xcel_3g_model(self):
+        pkt = make_packet(CommandType.USER_INTERFACE, "171400")
         event = PanelVersionUpdate.decode(pkt)
-        self.assertEqual(event.model, PanelVersionUpdate.Model.D16X_3G)
+        self.assertEqual(event.model, PanelVersionUpdate.Model.D16X_CEL_3G)
 
-    def test_4g_model(self):
-        pkt = make_packet(CommandType.USER_INTERFACE, "161400")
+    def test_d16xcel_4g_model(self):
+        pkt = make_packet(CommandType.USER_INTERFACE, "171500")
         event = PanelVersionUpdate.decode(pkt)
-        self.assertEqual(event.model, PanelVersionUpdate.Model.D16XCEL)
+        self.assertEqual(event.model, PanelVersionUpdate.Model.D16X_CEL_4G)
 
     def test_sw_version(self):
-        pkt = make_packet(CommandType.USER_INTERFACE, "160086")
+        pkt = make_packet(CommandType.USER_INTERFACE, "170086")
         event = PanelVersionUpdate.decode(pkt)
         self.assertEqual(event.major_version, 8)
         self.assertEqual(event.minor_version, 6)


### PR DESCRIPTION
## Summary
- hardcode panel version hexes for D8X/D16X variants and modems
- cover new panel versions in tests

## Testing
- `pytest nessclient_tests/test_event.py::PanelVersionUpdateTestCase::test_d8x_model -q`
- `pytest -q` *(fails: async def functions are not natively supported; missing pytest-asyncio)*

------
https://chatgpt.com/codex/tasks/task_e_68a31955cdf883318311118f502b40ab