### PR TITLE
Use MyST for docs and test build in CI

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -25,6 +25,24 @@ jobs:
         run: uv run black --check nessclient nessclient_tests
       - name: 'Check Types'
         run: uv run mypy --strict nessclient
+  docs:
+    name: "Docs"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.12"
+      - name: 'Install Dependencies'
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install uv
+          uv sync --dev
+          uv run pip install -r docs/requirements.txt
+      - name: 'Build Docs'
+        run: uv run sphinx-build -W -b html docs docs/_build/html
   build:
     name: "Build and Test"
     runs-on: ubuntu-latest

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,22 +2,23 @@
 
 ## nessclient Core
 
-.. automodule:: nessclient
-    :members:
-    :undoc-members:
-    :exclude-members: BaseEvent
+```{automodule} nessclient
+:members:
+:undoc-members:
+:exclude-members: BaseEvent
+```
 
 ## nessclient.event
 
-.. automodule:: nessclient.event
-    :members:
-    :undoc-members:
+```{automodule} nessclient.event
+:members:
+:undoc-members:
+```
 
 
 ## nessclient.connection
 
-.. automodule:: nessclient.connection
-    :members:
-    :undoc-members:
-
-.
+```{automodule} nessclient.connection
+:members:
+:undoc-members:
+```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,7 +45,7 @@ release = ''
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'm2r',
+    'myst_parser',
     'sphinx.ext.autodoc',
 ]
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -3,12 +3,12 @@
 ## Sending Commands
 A list of commands that can be sent can be found in the _Input Commands_ section of the [protocol documentation](http://www.nesscorporation.com/Software/Ness_D8-D16_ASCII_protocol.pdf). Additional information on the user-level commands available can be found in the _Operation Summary_ of the [installer manual](http://nesscorporation.com/InstallationManual/D8xD16x_installer_manual_rev7.7.pdf).
 
-.. literalinclude:: ../examples/sending_commands.py
-   :language: python
+```{literalinclude} ../examples/sending_commands.py
+:language: python
+```
 
 ## Listening for Events
 
-.. literalinclude:: ../examples/listening_for_events.py
-   :language: python
-
-.
+```{literalinclude} ../examples/listening_for_events.py
+:language: python
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,3 @@
-.. nessclient documentation master file, created by
-   sphinx-quickstart on Fri Nov 16 07:34:39 2018.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
 # nessclient
 
 [![](https://travis-ci.org/nickw444/nessclient.svg?branch=master)](https://travis-ci.org/nickw444/nessclient)
@@ -20,17 +15,18 @@ A python implementation/abstraction of the [Ness D8x / D16x Serial Interface ASC
 pip install nessclient
 ```
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-   
-   cli.md
-   api.md
-   examples.md
-   developing.md
+```{toctree}
+:maxdepth: 2
+:caption: Contents:
+
+cli.md
+api.md
+examples.md
+developing.md
+```
 
 # Indices and tables
 
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`
+* {ref}`genindex`
+* {ref}`modindex`
+* {ref}`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
 .
 sphinx
-m2r
+myst-parser


### PR DESCRIPTION
## Summary
- migrate docs to MyST parser
- add CI job to build docs

## Testing
- `uv run sphinx-build -b html docs docs/_build/html`
- `uv run black nessclient nessclient_tests`
- `uv run flake8 nessclient nessclient_tests`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a44ee3e0ec8331a5bfd56416b91e44