### PR TITLE
Add panel version arguments to dummy alarm server

### DIFF
--- a/nessclient/cli/server/__init__.py
+++ b/nessclient/cli/server/__init__.py
@@ -1,6 +1,7 @@
 import click
 
 from .alarm_server import AlarmServer
+from ...event import PanelVersionUpdate
 
 DEFAULT_PORT = 65432
 
@@ -8,6 +9,22 @@ DEFAULT_PORT = 65432
 @click.command(help="Run a dummy server")
 @click.option("--host", default="127.0.0.1")
 @click.option("--port", default=DEFAULT_PORT)
-def server(host: str, port: int) -> None:
-    s = AlarmServer(host=host, port=port)
+@click.option(
+    "--panel-model",
+    type=click.Choice(
+        [m.name for m in PanelVersionUpdate.Model], case_sensitive=False
+    ),
+    default=PanelVersionUpdate.Model.D8X.name,
+)
+@click.option("--panel-version", default="5.8")
+def server(host: str, port: int, panel_model: str, panel_version: str) -> None:
+    model = PanelVersionUpdate.Model[panel_model.upper()]
+    major_str, minor_str = panel_version.split(".")
+    s = AlarmServer(
+        host=host,
+        port=port,
+        panel_model=model,
+        panel_major=int(major_str),
+        panel_minor=int(minor_str),
+    )
     s.start()


### PR DESCRIPTION
## Summary
- allow dummy alarm server to specify panel model and version via `--panel-model` and `--panel-version`
- respond to `S17` commands with `PanelVersionUpdate`
- remove dummy alarm server tests

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'serial_asyncio_fast')*


------
https://chatgpt.com/codex/tasks/task_e_68a44c20877c8331ba76a05b6d4b8931