### PR TITLE
feat: add panel version opts to dummy server

### DIFF
--- a/nessclient/cli/server/__init__.py
+++ b/nessclient/cli/server/__init__.py
@@ -1,6 +1,7 @@
 import click
 
 from .alarm_server import AlarmServer
+from ...event import PanelVersionUpdate
 
 DEFAULT_PORT = 65432
 
@@ -8,6 +9,19 @@ DEFAULT_PORT = 65432
 @click.command(help="Run a dummy server")
 @click.option("--host", default="127.0.0.1")
 @click.option("--port", default=DEFAULT_PORT)
-def server(host: str, port: int) -> None:
-    s = AlarmServer(host=host, port=port)
+@click.option(
+    "--panel-model",
+    type=click.Choice([m.name for m in PanelVersionUpdate.Model]),
+    default=PanelVersionUpdate.Model.D8X.name,
+)
+@click.option("--panel-version", default="0.0")
+def server(host: str, port: int, panel_model: str, panel_version: str) -> None:
+    major_str, minor_str = panel_version.split(".")
+    s = AlarmServer(
+        host=host,
+        port=port,
+        panel_model=PanelVersionUpdate.Model[panel_model],
+        panel_major_version=int(major_str),
+        panel_minor_version=int(minor_str),
+    )
     s.start()

--- a/nessclient/cli/server/alarm_server.py
+++ b/nessclient/cli/server/alarm_server.py
@@ -7,13 +7,26 @@ from typing import List, Iterator
 from .alarm import Alarm
 from .server import Server, get_zone_state_event_type
 from .zone import Zone
-from ...event import SystemStatusEvent, ArmingUpdate, ZoneUpdate, StatusUpdate
+from ...event import (
+    SystemStatusEvent,
+    ArmingUpdate,
+    ZoneUpdate,
+    StatusUpdate,
+    PanelVersionUpdate,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class AlarmServer:
-    def __init__(self, host: str, port: int):
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        panel_model: PanelVersionUpdate.Model,
+        panel_major_version: int,
+        panel_minor_version: int,
+    ):
         self._alarm = Alarm.create(
             num_zones=8,
             alarm_state_changed=self._alarm_state_changed,
@@ -23,6 +36,9 @@ class AlarmServer:
         self._host = host
         self._port = port
         self._simulation_running = False
+        self._panel_model = panel_model
+        self._panel_major_version = panel_major_version
+        self._panel_minor_version = panel_minor_version
 
     def start(self) -> None:
         self._server.start(host=self._host, port=self._port)
@@ -88,6 +104,8 @@ class AlarmServer:
             self._handle_zone_input_unsealed_status_update_request()
         elif command == "S14":
             self._handle_arming_status_update_request()
+        elif command == "S17":
+            self._handle_panel_version_update_request()
 
     def _handle_arming_status_update_request(self) -> None:
         event = ArmingUpdate(
@@ -105,6 +123,16 @@ class AlarmServer:
                 for z in self._alarm.zones
                 if z.state == Zone.State.UNSEALED
             ],
+            address=0x00,
+            timestamp=None,
+        )
+        self._server.write_event(event)
+
+    def _handle_panel_version_update_request(self) -> None:
+        event = PanelVersionUpdate(
+            model=self._panel_model,
+            major_version=self._panel_major_version,
+            minor_version=self._panel_minor_version,
             address=0x00,
             timestamp=None,
         )

--- a/nessclient/event.py
+++ b/nessclient/event.py
@@ -469,6 +469,22 @@ class PanelVersionUpdate(StatusUpdate):
     def version(self) -> str:
         return "{}.{}".format(self.major_version, self.minor_version)
 
+    def encode(self) -> Packet:
+        data = "{:02x}{:02x}{:x}{:x}".format(
+            self.request_id.value,
+            self.model.value,
+            self.major_version,
+            self.minor_version,
+        )
+        return Packet(
+            address=self.address,
+            seq=0x00,
+            command=CommandType.USER_INTERFACE,
+            data=data,
+            timestamp=None,
+            is_user_interface_resp=True,
+        )
+
     @classmethod
     def decode(cls, packet: Packet) -> "PanelVersionUpdate":
         model = PanelVersionUpdate.Model(int(packet.data[2:4], 16))


### PR DESCRIPTION
## Summary
- allow the fake alarm server to specify panel model and version via `--panel-model` and `--panel-version`
- send a PanelVersionUpdate in response to `S17` using provided model/version
- add encoding support for `PanelVersionUpdate`

## Testing
- `uv run ruff format nessclient nessclient_tests`
- `uv run ruff check nessclient nessclient_tests`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a46920e3188331a7041e73ffc0613c