### PR TITLE
Run ruff on examples and entire repo

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -20,9 +20,9 @@ jobs:
           python -m pip install uv
           uv sync --dev
       - name: 'Lint (ruff)'
-        run: uv run ruff check nessclient nessclient_tests
+        run: uv run ruff check .
       - name: 'Check Formatting (ruff)'
-        run: uv run ruff format --check nessclient nessclient_tests
+        run: uv run ruff format --check .
       - name: 'Check Types'
         run: uv run mypy --strict nessclient
   docs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@ This repository uses [uv](https://docs.astral.sh/uv/) for dependency management 
 - Install dependencies with `uv sync --dev`.
 
 ## Style, Linting, and Type Checking
-- Format Python code with `uv run ruff format nessclient nessclient_tests`.
-- Lint with `uv run ruff check nessclient nessclient_tests`.
+- Format Python code with `uv run ruff format .`.
+- Lint with `uv run ruff check .`.
 - Run type checks using `uv run mypy --strict nessclient`.
 
 ## Testing

--- a/examples/listening_for_events.py
+++ b/examples/listening_for_events.py
@@ -3,30 +3,32 @@ import asyncio
 from nessclient import Client, ArmingState, ArmingMode, BaseEvent
 
 loop = asyncio.get_event_loop()
-host = '127.0.0.1'
+host = "127.0.0.1"
 port = 65432
 client = Client(host=host, port=port)
 
 
 @client.on_zone_change
 def on_zone_change(zone: int, triggered: bool):
-    print('Zone {} changed to {}'.format(zone, triggered))
+    print("Zone {} changed to {}".format(zone, triggered))
 
 
 @client.on_state_change
 def on_state_change(state: ArmingState, _arming_mode: ArmingMode | None):
-    print('Alarm state changed to {}'.format(state))
+    print("Alarm state changed to {}".format(state))
 
 
 @client.on_event_received
 def on_event_received(event: BaseEvent):
-    print('Event received:', event)
+    print("Event received:", event)
 
 
-loop.run_until_complete(asyncio.gather(
-    client.keepalive(),
-    client.update(),
-))
+loop.run_until_complete(
+    asyncio.gather(
+        client.keepalive(),
+        client.update(),
+    )
+)
 
 client.close()
 loop.close()

--- a/examples/sending_commands.py
+++ b/examples/sending_commands.py
@@ -3,22 +3,22 @@ import asyncio
 from nessclient import Client
 
 loop = asyncio.get_event_loop()
-host = '127.0.0.1'
+host = "127.0.0.1"
 port = 65432
 client = Client(host=host, port=port)
 
 # Send arming command via library abstraction
-loop.run_until_complete(client.arm_away('1234'))
+loop.run_until_complete(client.arm_away("1234"))
 # Send panic command via library abstraction
-loop.run_until_complete(client.panic('1234'))
+loop.run_until_complete(client.panic("1234"))
 # Send disarm command via library abstraction
-loop.run_until_complete(client.disarm('1234'))
+loop.run_until_complete(client.disarm("1234"))
 # Send aux control command for output 2 via library abstraction
 loop.run_until_complete(client.aux(2))
 # Send custom command
 # In this instance, we are sending a status update command to view
 # output status
-loop.run_until_complete(client.send_command('S15'))
+loop.run_until_complete(client.send_command("S15"))
 
 client.close()
 loop.close()


### PR DESCRIPTION
## Summary
- format example scripts using `ruff format`
- lint and format the whole repo in CI to cover examples
- document new ruff instructions for contributors

## Testing
- `uv run ruff check .`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5b82820488331904d9280422de07f