### PR TITLE
refactor: replace Optional with union syntax

### DIFF
--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional, Callable, List
+from typing import Callable, List
 
 from .event import BaseEvent, ZoneUpdate, ArmingUpdate, SystemStatusEvent
 
@@ -41,7 +41,7 @@ class Alarm:
 
     @dataclass
     class Zone:
-        triggered: Optional[bool]
+        triggered: bool | None
 
     def __init__(self, infer_arming_state: bool = False) -> None:
         self._infer_arming_state = infer_arming_state
@@ -50,10 +50,10 @@ class Alarm:
 
         self._arming_mode: ArmingMode | None = None
 
-        self._on_state_change: Optional[
-            Callable[[ArmingState, ArmingMode | None], None]
-        ] = None
-        self._on_zone_change: Optional[Callable[[int, bool], None]] = None
+        self._on_state_change: Callable[[ArmingState, ArmingMode | None], None] | None = (
+            None
+        )
+        self._on_zone_change: Callable[[int, bool], None] | None = None
 
     def handle_event(self, event: BaseEvent) -> None:
         if isinstance(event, ArmingUpdate):

--- a/nessclient/cli/server/alarm.py
+++ b/nessclient/cli/server/alarm.py
@@ -3,7 +3,7 @@ import threading
 import time
 import uuid
 from enum import Enum
-from typing import List, Callable, Optional
+from typing import List, Callable
 
 from .zone import Zone
 
@@ -46,7 +46,7 @@ class Alarm:
         self._arming_mode: Alarm.ArmingMode | None = None
         self._alarm_state_changed = _alarm_state_changed
         self._zone_state_changed = _zone_state_changed
-        self._pending_event: Optional[str] = None
+        self._pending_event: str | None = None
 
     @staticmethod
     def create(

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime
 import logging
 from asyncio import sleep
-from typing import Optional, Callable
+from typing import Callable
 
 from justbackoff import Backoff
 
@@ -25,14 +25,14 @@ class Client:
 
     def __init__(
         self,
-        connection: Optional[Connection] = None,
-        host: Optional[str] = None,
-        port: Optional[int] = None,
-        serial_tty: Optional[str] = None,
+        connection: Connection | None = None,
+        host: str | None = None,
+        port: int | None = None,
+        serial_tty: str | None = None,
         update_interval: int = 60,
         infer_arming_state: bool = False,
-        alarm: Optional[Alarm] = None,
-        decode_options: Optional[DecodeOptions] = None,
+        alarm: Alarm | None = None,
+        decode_options: DecodeOptions | None = None,
     ):
         if connection is None:
             if host is not None and port is not None:
@@ -49,19 +49,19 @@ class Client:
 
         self.alarm = alarm
         self._decode_options = decode_options
-        self._on_event_received: Optional[Callable[[BaseEvent], None]] = None
+        self._on_event_received: Callable[[BaseEvent], None] | None = None
         self._connection = connection
         self._closed = False
         self._backoff = Backoff()
         self._connect_lock = asyncio.Lock()
-        self._last_recv: Optional[datetime.datetime] = None
+        self._last_recv: datetime.datetime | None = None
         self._update_interval = update_interval
 
-    async def arm_away(self, code: Optional[str] = None) -> None:
+    async def arm_away(self, code: str | None = None) -> None:
         command = "A{}E".format(code if code else "")
         return await self.send_command(command)
 
-    async def arm_home(self, code: Optional[str] = None) -> None:
+    async def arm_home(self, code: str | None = None) -> None:
         command = "H{}E".format(code if code else "")
         return await self.send_command(command)
 

--- a/nessclient/connection.py
+++ b/nessclient/connection.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from abc import ABC, abstractmethod
-from typing import Optional
 import serial
 from serial_asyncio_fast import SerialTransport, create_serial_connection
 
@@ -12,7 +11,7 @@ class Connection(ABC):
     """Represents a connection to a Ness D8X/D16X server"""
 
     @abstractmethod
-    async def read(self) -> Optional[bytes]:
+    async def read(self) -> bytes | None:
         raise NotImplementedError()
 
     @abstractmethod
@@ -40,14 +39,14 @@ class AsyncIoConnection(Connection, ABC):
         super().__init__()
 
         self._write_lock = asyncio.Lock()
-        self._reader: Optional[asyncio.StreamReader] = None
-        self._writer: Optional[asyncio.StreamWriter] = None
+        self._reader: asyncio.StreamReader | None = None
+        self._writer: asyncio.StreamWriter | None = None
 
     @property
     def connected(self) -> bool:
         return self._reader is not None and self._writer is not None
 
-    async def read(self) -> Optional[bytes]:
+    async def read(self) -> bytes | None:
         assert self._reader is not None
 
         try:
@@ -111,7 +110,7 @@ class Serial232Connection(AsyncIoConnection):
         super().__init__()
 
         self._tty_path = tty_path
-        self._serial_connection: Optional[serial.Serial] = None
+        self._serial_connection: serial.Serial | None = None
 
     @property
     def connected(self) -> bool:

--- a/nessclient/event.py
+++ b/nessclient/event.py
@@ -2,7 +2,7 @@ import dataclasses
 import datetime
 import struct
 from enum import Enum
-from typing import List, Optional, TypeVar, Type, Dict
+from typing import List, TypeVar, Type, Dict
 
 from .packet import CommandType, Packet
 
@@ -36,7 +36,7 @@ class DecodeOptions:
 
 
 class BaseEvent(object):
-    def __init__(self, address: Optional[int], timestamp: Optional[datetime.datetime]):
+    def __init__(self, address: int | None, timestamp: datetime.datetime | None):
         self.address = address
         self.timestamp = timestamp
 
@@ -104,8 +104,8 @@ class SystemStatusEvent(BaseEvent):
         type: "SystemStatusEvent.EventType",
         zone: int,
         area: int,
-        address: Optional[int],
-        timestamp: Optional[datetime.datetime],
+        address: int | None,
+        timestamp: datetime.datetime | None,
     ) -> None:
         super(SystemStatusEvent, self).__init__(address=address, timestamp=timestamp)
         self.type = type
@@ -164,8 +164,8 @@ class StatusUpdate(BaseEvent):
     def __init__(
         self,
         request_id: "StatusUpdate.RequestID",
-        address: Optional[int],
-        timestamp: Optional[datetime.datetime],
+        address: int | None,
+        timestamp: datetime.datetime | None,
     ) -> None:
         super(StatusUpdate, self).__init__(address=address, timestamp=timestamp)
         self.request_id = request_id
@@ -216,8 +216,8 @@ class ZoneUpdate(StatusUpdate):
         self,
         included_zones: List["ZoneUpdate.Zone"],
         request_id: "StatusUpdate.RequestID",
-        address: Optional[int],
-        timestamp: Optional[datetime.datetime],
+        address: int | None,
+        timestamp: datetime.datetime | None,
     ) -> None:
         super(ZoneUpdate, self).__init__(
             request_id=request_id, address=address, timestamp=timestamp
@@ -277,8 +277,8 @@ class MiscellaneousAlarmsUpdate(StatusUpdate):
     def __init__(
         self,
         included_alarms: List["MiscellaneousAlarmsUpdate.AlarmType"],
-        address: Optional[int],
-        timestamp: Optional[datetime.datetime],
+        address: int | None,
+        timestamp: datetime.datetime | None,
     ):
         super(MiscellaneousAlarmsUpdate, self).__init__(
             request_id=StatusUpdate.RequestID.MISCELLANEOUS_ALARMS,
@@ -327,8 +327,8 @@ class ArmingUpdate(StatusUpdate):
     def __init__(
         self,
         status: List["ArmingUpdate.ArmingStatus"],
-        address: Optional[int],
-        timestamp: Optional[datetime.datetime],
+        address: int | None,
+        timestamp: datetime.datetime | None,
     ):
         super(ArmingUpdate, self).__init__(
             request_id=StatusUpdate.RequestID.ARMING,
@@ -394,8 +394,8 @@ class OutputsUpdate(StatusUpdate):
     def __init__(
         self,
         outputs: List["OutputsUpdate.OutputType"],
-        address: Optional[int],
-        timestamp: Optional[datetime.datetime],
+        address: int | None,
+        timestamp: datetime.datetime | None,
     ):
         super(OutputsUpdate, self).__init__(
             request_id=StatusUpdate.RequestID.OUTPUTS,
@@ -429,8 +429,8 @@ class ViewStateUpdate(StatusUpdate):
     def __init__(
         self,
         state: "ViewStateUpdate.State",
-        address: Optional[int],
-        timestamp: Optional[datetime.datetime],
+        address: int | None,
+        timestamp: datetime.datetime | None,
     ):
         super(ViewStateUpdate, self).__init__(
             request_id=StatusUpdate.RequestID.VIEW_STATE,
@@ -533,9 +533,9 @@ class PanelVersionUpdate(StatusUpdate):
         model: Model,
         major_version: int,
         minor_version: int,
-        address: Optional[int],
-        timestamp: Optional[datetime.datetime],
-        _model_mapper: Optional[Dict[int, Model]] = None,
+        address: int | None,
+        timestamp: datetime.datetime | None,
+        _model_mapper: Dict[int, Model] | None = None,
     ):
         super(PanelVersionUpdate, self).__init__(
             request_id=StatusUpdate.RequestID.PANEL_VERSION,
@@ -610,8 +610,8 @@ class AuxiliaryOutputsUpdate(StatusUpdate):
     def __init__(
         self,
         outputs: List[OutputType],
-        address: Optional[int],
-        timestamp: Optional[datetime.datetime],
+        address: int | None,
+        timestamp: datetime.datetime | None,
     ):
         super(AuxiliaryOutputsUpdate, self).__init__(
             request_id=StatusUpdate.RequestID.AUXILIARY_OUTPUTS,

--- a/nessclient/packet.py
+++ b/nessclient/packet.py
@@ -2,7 +2,6 @@ import datetime
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -14,11 +13,11 @@ class CommandType(Enum):
 
 @dataclass
 class Packet:
-    address: Optional[int]
+    address: int | None
     seq: int
     command: CommandType
     data: str
-    timestamp: Optional[datetime.datetime]
+    timestamp: datetime.datetime | None
 
     # Whether or not this packet is a USER_INTERFACE response
     is_user_interface_resp: bool = False


### PR DESCRIPTION
## Summary
- refactor typing hints to use `T | None` instead of `Optional[T]`

## Testing
- `uv run ruff check nessclient nessclient_tests`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5b967ca088331b3d994eed80425c2