### PR TITLE
Add interactive UI for dummy alarm server

### DIFF
--- a/nessclient/cli/server/alarm.py
+++ b/nessclient/cli/server/alarm.py
@@ -48,6 +48,10 @@ class Alarm:
         self._zone_state_changed = _zone_state_changed
         self._pending_event: str | None = None
 
+    @property
+    def arming_mode(self) -> "Alarm.ArmingMode | None":
+        return self._arming_mode
+
     @staticmethod
     def create(
         num_zones: int,

--- a/nessclient/cli/server/server.py
+++ b/nessclient/cli/server/server.py
@@ -1,7 +1,8 @@
 import logging
 import socket
 import threading
-from typing import List, Callable, Any
+import traceback
+from typing import List, Callable, Any, Optional
 
 from .zone import Zone
 from ...event import BaseEvent, SystemStatusEvent
@@ -11,14 +12,21 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Server:
-    def __init__(self, handle_command: Callable[[str], None]):
+    def __init__(
+        self,
+        handle_command: Callable[[str], None],
+        log_callback: Optional[Callable[[str], None]] = None,
+        rx_callback: Optional[Callable[[str, Optional[Packet]], None]] = None,
+    ):
         self._handle_command = handle_command
+        self._log_callback = log_callback
+        self._rx_callback = rx_callback
         self._handle_event_lock: threading.Lock = threading.Lock()
         self._clients_lock: threading.Lock = threading.Lock()
         self._clients: List[socket.socket] = []
 
     def start(self, host: str, port: int) -> None:
-        threading.Thread(target=self._loop, args=(host, port)).start()
+        threading.Thread(target=self._loop, args=(host, port), daemon=True).start()
 
     def _loop(self, host: str, port: int) -> None:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -30,7 +38,7 @@ class Server:
             while True:
                 conn, addr = s.accept()
                 threading.Thread(
-                    target=self._on_client_connected, args=(conn, addr)
+                    target=self._on_client_connected, args=(conn, addr), daemon=True
                 ).start()
 
     def write_event(self, event: BaseEvent) -> None:
@@ -53,16 +61,34 @@ class Server:
         with self._clients_lock:
             self._clients.append(conn)
 
-        while True:
-            data = conn.recv(1024)
-            if data is None or len(data) == 0:
-                _LOGGER.info("client %s disconnected", addr)
-                with self._clients_lock:
+        buffer = b""
+        try:
+            while True:
+                data = conn.recv(1024)
+                if not data:
+                    _LOGGER.info("client %s disconnected", addr)
+                    break
+                buffer += data
+                # Process complete CRLF-terminated lines
+                while True:
+                    idx = buffer.find(b"\r\n")
+                    if idx == -1:
+                        break
+                    line = buffer[:idx]
+                    buffer = buffer[idx + 2 :]
+                    line_str = line.decode("utf-8", errors="ignore")
+                    if line_str:
+                        self._handle_incoming_line(line_str)
+        finally:
+            with self._clients_lock:
+                try:
                     self._clients.remove(conn)
-
-                break
-
-            self._handle_incoming_data(data)
+                except ValueError:
+                    pass
+            try:
+                conn.close()
+            except Exception:
+                pass
 
     def _write_to_all_clients(self, data: str) -> None:
         _LOGGER.debug("Writing message '%s' to all clients", data)
@@ -70,17 +96,41 @@ class Server:
             for conn in self._clients:
                 conn.send(data.encode("utf-8") + b"\r\n")
 
-    def _handle_incoming_data(self, data: bytes) -> None:
-        _LOGGER.debug("Received incoming data: %s", data)
-        pkt = Packet.decode(data.strip().decode("utf-8"))
-        _LOGGER.debug("Packet is: %s", pkt)
-        # Handle Incoming Command:
-        if pkt.command == CommandType.USER_INTERFACE and not pkt.is_user_interface_resp:
-            _LOGGER.info("Handling User interface incoming: %s", pkt.data)
-            with self._handle_event_lock:
-                self._handle_command(pkt.data)
-        else:
-            raise NotImplementedError()
+    def _handle_incoming_line(self, line: str) -> None:
+        _LOGGER.debug("Received incoming line: %s", line)
+        try:
+            pkt = Packet.decode(line)
+            _LOGGER.debug("Packet is: %s", pkt)
+            if self._rx_callback is not None:
+                try:
+                    self._rx_callback(line, pkt)
+                except Exception:
+                    _LOGGER.debug("rx_callback raised, ignoring", exc_info=True)
+            # Handle Incoming Command:
+            if (
+                pkt.command == CommandType.USER_INTERFACE
+                and not pkt.is_user_interface_resp
+            ):
+                _LOGGER.info("Handling User interface incoming: %s", pkt.data)
+                with self._handle_event_lock:
+                    self._handle_command(pkt.data)
+            else:
+                raise NotImplementedError()
+        except Exception as e:
+            msg = (
+                f"Error decoding or handling line: {repr(line)}\n"
+                f"{e}\n"
+                f"{traceback.format_exc()}"
+            )
+            if self._rx_callback is not None:
+                try:
+                    self._rx_callback(line, None)
+                except Exception:
+                    _LOGGER.debug("rx_callback raised, ignoring", exc_info=True)
+            if self._log_callback is not None:
+                self._log_callback(msg)
+            else:
+                _LOGGER.exception("Failed to handle incoming line")
 
 
 def get_zone_state_event_type(state: Zone.State) -> SystemStatusEvent.EventType:


### PR DESCRIPTION
## Summary
- add arming_mode accessor on Alarm
- run dummy alarm server with a curses-based interactive UI for zones and arming commands

## Testing
- `uv run ruff check .`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a5be08f6508331863819c1d3f2c3d9

<img width="1179" height="1077" alt="image" src="https://github.com/user-attachments/assets/e465709c-87f1-4ee8-862e-9aca6b939db6" />
