### PR TITLE
Install CLI extras during uv sync

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -18,7 +18,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install uv
-          uv sync --dev
+          uv sync --dev --all-extras
       - name: 'Lint (ruff)'
         run: uv run ruff check .
       - name: 'Check Formatting (ruff)'
@@ -39,7 +39,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install uv
-          uv sync --dev
+          uv sync --dev --all-extras
           uv run pip install -r docs/requirements.txt
       - name: 'Build Docs'
         run: uv run sphinx-build -W -b html docs docs/_build/html
@@ -61,7 +61,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install uv
-          uv sync --dev
+          uv sync --dev --all-extras
 
       - name: 'Run Tests (with coverage)'
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository uses [uv](https://docs.astral.sh/uv/) for dependency management 
 - Refer to [`D8-32X Serial Protocol Public.md`](./D8-32X%20Serial%20Protocol%20Public.md) for details on the device protocol.
 
 ## Setup
-- Install dependencies with `uv sync --dev`.
+- Install dependencies with `uv sync --dev --all-extras`.
 
 ## Style, Linting, and Type Checking
 - Format Python code with `uv run ruff format .`.

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -1,8 +1,9 @@
 # Developing
-Use [uv](https://docs.astral.sh/uv/) to set up the local environment:
+Use [uv](https://docs.astral.sh/uv/) to set up the local environment and
+install optional extras such as the CLI tools:
 
 ```sh
-uv sync --dev
+uv sync --dev --all-extras
 ```
 
 ## Running tests


### PR DESCRIPTION
## Summary
- include optional extras when syncing dependencies so the CLI (click) is available during local development
- update docs and CI to run `uv sync --dev --all-extras`

## Testing
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a64a32210c8331bac6c59aa2665295