### PR TITLE
Add 32‑zone support (client/events/server) and comprehensive tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ The CLI exposes several high level commands:
 
 Run `ness-cli COMMAND --help` for full options on each command.
 
+#### Server zones
+
+The dummy server can simulate a configurable number of zones independent of the panel model. Use `--zones` to set the count (1–32):
+
+```
+ness-cli server --zones 24 --panel-model D8X --panel-version 8.7
+```
+
+- `S00` status includes unsealed zones in 1–16 (or fewer if the configured count is < 16).
+- `S20` always responds: it returns an empty set when the configured count is ≤ 16; otherwise it reports unsealed zones in 17–N.
+
 ### Capturing raw packets
 
 When reporting issues it can be helpful to provide the raw ASCII packets

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -53,7 +53,10 @@ class Alarm:
     def __init__(self, infer_arming_state: bool = False) -> None:
         self._infer_arming_state = infer_arming_state
         self.arming_state: ArmingState = ArmingState.UNKNOWN
-        self._zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(32)]
+        # Always expose all 32 zones irrespective of panel model, as some panels
+        # can be "expanded" to support more zones, but there is no API/command
+        # to query the existence of these zones.
+        self.zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(32)]
 
         self.panel_model: PanelVersionUpdate.Model | None = None
         self.panel_version: str | None = None
@@ -64,13 +67,6 @@ class Alarm:
             None
         )
         self._on_zone_change: Callable[[int, bool], None] | None = None
-
-    @property
-    def zones(self) -> List[Zone]:
-        if self.panel_model is None or self.panel_model == PanelVersionUpdate.Model.D32X:
-            return self._zones
-
-        return self._zones[:16]
 
     def handle_event(self, event: BaseEvent) -> None:
         if isinstance(event, ArmingUpdate):

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, List
+
 from .event import (
     BaseEvent,
     ZoneUpdate_1_16,

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, List
 
+from .event import PanelVersionUpdate
 from .event import (
     BaseEvent,
     ZoneUpdate_1_16,
@@ -52,7 +53,10 @@ class Alarm:
     def __init__(self, infer_arming_state: bool = False) -> None:
         self._infer_arming_state = infer_arming_state
         self.arming_state: ArmingState = ArmingState.UNKNOWN
-        self.zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(32)]
+        self._zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(32)]
+
+        self.panel_model: PanelVersionUpdate.Model | None = None
+        self.panel_version: str | None = None
 
         self._arming_mode: ArmingMode | None = None
 
@@ -60,6 +64,13 @@ class Alarm:
             None
         )
         self._on_zone_change: Callable[[int, bool], None] | None = None
+
+    @property
+    def zones(self) -> List[Zone]:
+        if self.panel_model == PanelVersionUpdate.Model.D32X:
+            return self._zones
+
+        return self._zones[:16]
 
     def handle_event(self, event: BaseEvent) -> None:
         if isinstance(event, ArmingUpdate):

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, List
 
-from .event import BaseEvent, ZoneUpdate, ArmingUpdate, SystemStatusEvent
+from .event import BaseEvent, ZoneUpdate_1_16, ZoneUpdate_17_32, ArmingUpdate, SystemStatusEvent
 
 
 class ArmingState(Enum):
@@ -46,7 +46,7 @@ class Alarm:
     def __init__(self, infer_arming_state: bool = False) -> None:
         self._infer_arming_state = infer_arming_state
         self.arming_state: ArmingState = ArmingState.UNKNOWN
-        self.zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(16)]
+        self.zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(32)]
 
         self._arming_mode: ArmingMode | None = None
 
@@ -59,10 +59,15 @@ class Alarm:
         if isinstance(event, ArmingUpdate):
             self._handle_arming_update(event)
         elif (
-            isinstance(event, ZoneUpdate)
-            and event.request_id == ZoneUpdate.RequestID.ZONE_INPUT_UNSEALED
+            isinstance(event, ZoneUpdate_1_16)
+            and event.request_id == ZoneUpdate_1_16.RequestID.ZONE_1_16_INPUT_UNSEALED
         ):
-            self._handle_zone_input_update(event)
+            self._handle_zone_1_16_input_update(event)
+        elif (
+                isinstance(event, ZoneUpdate_17_32)
+                and event.request_id == ZoneUpdate_17_32.RequestID.ZONE_17_32_INPUT_UNSEALED
+        ):
+            self._handle_zone_17_32_input_update(event)
         elif isinstance(event, SystemStatusEvent):
             self._handle_system_status_event(event)
 
@@ -95,14 +100,24 @@ class Alarm:
                 #  handles other arming modes.
                 return self._update_arming_state(ArmingState.DISARMED)
 
-    def _handle_zone_input_update(self, update: ZoneUpdate) -> None:
-        for i, zone in enumerate(self.zones):
+    def _handle_zone_1_16_input_update(self, update: ZoneUpdate_1_16) -> None:
+        for i, zone in enumerate(self.zones[:16]):
             zone_id = i + 1
             name = "ZONE_{}".format(zone_id)
-            if ZoneUpdate.Zone[name] in update.included_zones:
+            if ZoneUpdate_1_16.Zone[name] in update.included_zones:
                 self._update_zone(zone_id, True)
             else:
                 self._update_zone(zone_id, False)
+
+    def _handle_zone_17_32_input_update(self, update: ZoneUpdate_17_32) -> None:
+        for i, zone in enumerate(self.zones[16:]):
+            zone_id = i + 1
+            name = "ZONE_{}".format(zone_id)
+            if ZoneUpdate_17_32.Zone[name] in update.included_zones:
+                self._update_zone(zone_id, True)
+            else:
+                self._update_zone(zone_id, False)
+
 
     def _handle_system_status_event(self, event: SystemStatusEvent) -> None:
         """

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -2,7 +2,13 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, List
 
-from .event import BaseEvent, ZoneUpdate_1_16, ZoneUpdate_17_32, ArmingUpdate, SystemStatusEvent
+from .event import (
+    BaseEvent,
+    ZoneUpdate_1_16,
+    ZoneUpdate_17_32,
+    ArmingUpdate,
+    SystemStatusEvent,
+)
 
 
 class ArmingState(Enum):
@@ -64,8 +70,8 @@ class Alarm:
         ):
             self._handle_zone_1_16_input_update(event)
         elif (
-                isinstance(event, ZoneUpdate_17_32)
-                and event.request_id == ZoneUpdate_17_32.RequestID.ZONE_17_32_INPUT_UNSEALED
+            isinstance(event, ZoneUpdate_17_32)
+            and event.request_id == ZoneUpdate_17_32.RequestID.ZONE_17_32_INPUT_UNSEALED
         ):
             self._handle_zone_17_32_input_update(event)
         elif isinstance(event, SystemStatusEvent):
@@ -111,13 +117,12 @@ class Alarm:
 
     def _handle_zone_17_32_input_update(self, update: ZoneUpdate_17_32) -> None:
         for i, zone in enumerate(self.zones[16:]):
-            zone_id = i + 1
+            zone_id = i + 17
             name = "ZONE_{}".format(zone_id)
             if ZoneUpdate_17_32.Zone[name] in update.included_zones:
                 self._update_zone(zone_id, True)
             else:
                 self._update_zone(zone_id, False)
-
 
     def _handle_system_status_event(self, event: SystemStatusEvent) -> None:
         """

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, List
-
 from .event import (
     BaseEvent,
     ZoneUpdate_1_16,

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -31,6 +31,12 @@ class ArmingMode(Enum):
     ARMED_HIGHEST = "ARMED_HIGHEST"
 
 
+@dataclass
+class PanelInfo:
+    model: PanelVersionUpdate.Model
+    version: str
+
+
 class Alarm:
     """
     In-memory representation of the state of the alarm the client is connected
@@ -57,9 +63,7 @@ class Alarm:
         # can be "expanded" to support more zones, but there is no API/command
         # to query the existence of these zones.
         self.zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(32)]
-
-        self.panel_model: PanelVersionUpdate.Model | None = None
-        self.panel_version: str | None = None
+        self.panel_info: PanelInfo | None = None
 
         self._arming_mode: ArmingMode | None = None
 
@@ -83,6 +87,8 @@ class Alarm:
             self._handle_zone_17_32_input_update(event)
         elif isinstance(event, SystemStatusEvent):
             self._handle_system_status_event(event)
+        elif isinstance(event, PanelVersionUpdate):
+            self.panel_info = PanelInfo(model=event.model, version=event.version)
 
     def _handle_arming_update(self, update: ArmingUpdate) -> None:
         if update.status == [ArmingUpdate.ArmingStatus.AREA_1_ARMED]:

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -67,7 +67,7 @@ class Alarm:
 
     @property
     def zones(self) -> List[Zone]:
-        if self.panel_model == PanelVersionUpdate.Model.D32X:
+        if self.panel_model is None or self.panel_model == PanelVersionUpdate.Model.D32X:
             return self._zones
 
         return self._zones[:16]

--- a/nessclient/cli/events.py
+++ b/nessclient/cli/events.py
@@ -75,7 +75,16 @@ def events(
     def on_event_received(event: BaseEvent) -> None:
         print(event)
 
+    async def _init_panel_info() -> None:
+        try:
+            info = await client.get_panel_info()
+            print(f"Panel: {info.model.name} {info.version}")
+        except Exception as e:
+            # Non-fatal; continue receiving events
+            print(f"Failed to probe panel info: {e}")
+
     loop.create_task(client.keepalive())
     loop.create_task(client.update())
+    loop.create_task(_init_panel_info())
 
     loop.run_forever()

--- a/nessclient/cli/server/__init__.py
+++ b/nessclient/cli/server/__init__.py
@@ -10,16 +10,25 @@ DEFAULT_PORT = 65432
 @click.option("--host", default="127.0.0.1")
 @click.option("--port", default=DEFAULT_PORT)
 @click.option(
+    "--zones",
+    type=click.IntRange(1, 32),
+    default=16,
+    help="Number of zones to simulate (1-32)",
+)
+@click.option(
     "--panel-model",
     type=click.Choice([m.name for m in PanelVersionUpdate.Model]),
     default=PanelVersionUpdate.Model.D8X.name,
 )
 @click.option("--panel-version", default="0.0")
-def server(host: str, port: int, panel_model: str, panel_version: str) -> None:
+def server(
+    host: str, port: int, zones: int, panel_model: str, panel_version: str
+) -> None:
     major_str, minor_str = panel_version.split(".")
     s = AlarmServer(
         host=host,
         port=port,
+        num_zones=zones,
         panel_model=PanelVersionUpdate.Model[panel_model],
         panel_major_version=int(major_str),
         panel_minor_version=int(minor_str),

--- a/nessclient/cli/server/alarm_server.py
+++ b/nessclient/cli/server/alarm_server.py
@@ -376,8 +376,8 @@ class AlarmServer:
             request_id=StatusUpdate.RequestID.ZONE_1_16_INPUT_UNSEALED,
             included_zones=[
                 get_zone_for_id_1_16(z.id)
-                for z in self._alarm.zones
-                if 1 <= z.id <= 16 and z.state == Zone.State.UNSEALED
+                for z in self._alarm.zones[:16]
+                if z.state == Zone.State.UNSEALED
             ],
             address=0x00,
             timestamp=None,
@@ -390,8 +390,8 @@ class AlarmServer:
             request_id=StatusUpdate.RequestID.ZONE_17_32_INPUT_UNSEALED,
             included_zones=[
                 get_zone_for_id_17_32(z.id)
-                for z in self._alarm.zones
-                if 17 <= z.id <= 32 and z.state == Zone.State.UNSEALED
+                for z in self._alarm.zones[16:32]
+                if z.state == Zone.State.UNSEALED
             ],
             address=0x00,
             timestamp=None,

--- a/nessclient/cli/server/alarm_server.py
+++ b/nessclient/cli/server/alarm_server.py
@@ -13,7 +13,7 @@ from .zone import Zone
 from ...event import (
     SystemStatusEvent,
     ArmingUpdate,
-    ZoneUpdate,
+    ZoneUpdate_1_16,
     StatusUpdate,
     PanelVersionUpdate,
 )
@@ -368,8 +368,8 @@ class AlarmServer:
         self._server.write_event(event)
 
     def _handle_zone_input_unsealed_status_update_request(self) -> None:
-        event = ZoneUpdate(
-            request_id=StatusUpdate.RequestID.ZONE_INPUT_UNSEALED,
+        event = ZoneUpdate_1_16(
+            request_id=StatusUpdate.RequestID.ZONE_1_16_INPUT_UNSEALED,
             included_zones=[
                 get_zone_for_id(z.id)
                 for z in self._alarm.zones
@@ -512,6 +512,6 @@ def toggled_state(state: Zone.State) -> Zone.State:
         return Zone.State.SEALED
 
 
-def get_zone_for_id(zone_id: int) -> ZoneUpdate.Zone:
+def get_zone_for_id(zone_id: int) -> ZoneUpdate_1_16.Zone:
     key = "ZONE_{}".format(zone_id)
-    return ZoneUpdate.Zone[key]
+    return ZoneUpdate_1_16.Zone[key]

--- a/nessclient/cli/server/alarm_server.py
+++ b/nessclient/cli/server/alarm_server.py
@@ -14,6 +14,7 @@ from ...event import (
     SystemStatusEvent,
     ArmingUpdate,
     ZoneUpdate_1_16,
+    ZoneUpdate_17_32,
     StatusUpdate,
     PanelVersionUpdate,
 )
@@ -31,7 +32,7 @@ class AlarmServer:
         panel_minor_version: int,
     ):
         self._alarm = Alarm.create(
-            num_zones=16,
+            num_zones=(32 if panel_model == PanelVersionUpdate.Model.D32X else 16),
             alarm_state_changed=self._alarm_state_changed,
             zone_state_changed=self._zone_state_changed,
         )
@@ -352,7 +353,9 @@ class AlarmServer:
         elif command == "1234E":
             self._alarm.disarm()
         elif command == "S00":
-            self._handle_zone_input_unsealed_status_update_request()
+            self._handle_zone_1_16_input_unsealed_status_update_request()
+        elif command == "S20":
+            self._handle_zone_17_32_input_unsealed_status_update_request()
         elif command == "S14":
             self._handle_arming_status_update_request()
         elif command == "S17":
@@ -367,13 +370,27 @@ class AlarmServer:
         self._log_tx_event(event)
         self._server.write_event(event)
 
-    def _handle_zone_input_unsealed_status_update_request(self) -> None:
+    def _handle_zone_1_16_input_unsealed_status_update_request(self) -> None:
         event = ZoneUpdate_1_16(
             request_id=StatusUpdate.RequestID.ZONE_1_16_INPUT_UNSEALED,
             included_zones=[
-                get_zone_for_id(z.id)
+                get_zone_for_id_1_16(z.id)
                 for z in self._alarm.zones
-                if z.state == Zone.State.UNSEALED
+                if 1 <= z.id <= 16 and z.state == Zone.State.UNSEALED
+            ],
+            address=0x00,
+            timestamp=None,
+        )
+        self._log_tx_event(event)
+        self._server.write_event(event)
+
+    def _handle_zone_17_32_input_unsealed_status_update_request(self) -> None:
+        event = ZoneUpdate_17_32(
+            request_id=StatusUpdate.RequestID.ZONE_17_32_INPUT_UNSEALED,
+            included_zones=[
+                get_zone_for_id_17_32(z.id)
+                for z in self._alarm.zones
+                if 17 <= z.id <= 32 and z.state == Zone.State.UNSEALED
             ],
             address=0x00,
             timestamp=None,
@@ -512,6 +529,11 @@ def toggled_state(state: Zone.State) -> Zone.State:
         return Zone.State.SEALED
 
 
-def get_zone_for_id(zone_id: int) -> ZoneUpdate_1_16.Zone:
+def get_zone_for_id_1_16(zone_id: int) -> ZoneUpdate_1_16.Zone:
     key = "ZONE_{}".format(zone_id)
     return ZoneUpdate_1_16.Zone[key]
+
+
+def get_zone_for_id_17_32(zone_id: int) -> ZoneUpdate_17_32.Zone:
+    key = "ZONE_{}".format(zone_id)
+    return ZoneUpdate_17_32.Zone[key]

--- a/nessclient/cli/server/alarm_server.py
+++ b/nessclient/cli/server/alarm_server.py
@@ -27,12 +27,13 @@ class AlarmServer:
         self,
         host: str,
         port: int,
+        num_zones: int,
         panel_model: PanelVersionUpdate.Model,
         panel_major_version: int,
         panel_minor_version: int,
     ):
         self._alarm = Alarm.create(
-            num_zones=(32 if panel_model == PanelVersionUpdate.Model.D32X else 16),
+            num_zones=num_zones,
             alarm_state_changed=self._alarm_state_changed,
             zone_state_changed=self._zone_state_changed,
         )

--- a/nessclient/cli/tui.py
+++ b/nessclient/cli/tui.py
@@ -80,8 +80,6 @@ async def interactive_ui(
     # Initial update and panel version request
     _add_log(logs, "TX", "Update")
     await client.update()
-    _add_log(logs, "TX", "S17 (Panel Version)")
-    await client.send_command("S17")
 
     stdscr = curses.initscr()
     curses.noecho()

--- a/nessclient/cli/tui.py
+++ b/nessclient/cli/tui.py
@@ -9,7 +9,7 @@ from typing import TextIO
 from ..alarm import ArmingMode, ArmingState
 from ..client import Client
 from ..connection import IP232Connection, Serial232Connection
-from ..event import BaseEvent, PanelVersionUpdate
+from ..event import BaseEvent
 from .logging_connection import LoggingConnection
 
 

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -52,7 +52,6 @@ class Client:
         self._decode_options = decode_options
         self._on_event_received: Callable[[BaseEvent], None] | None = None
         self._connection = connection
-        self._model_probe_attempted = False
         self._closed = False
         self._backoff = Backoff()
         self._connect_lock = asyncio.Lock()

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -89,24 +89,21 @@ class Client:
             self._model_probe_attempted = True
             await self._probe_panel_model()
 
-        if len(self.alarm.zones) > 16:
-            _LOGGER.debug("Requesting state update from server (S00, S20, S14)")
-            await asyncio.gather(
-                # List unsealed Zones 1-16
-                self.send_command("S00"),
-                # List unsealed Zones 17-32
-                self.send_command("S20"),
-                # Arming status update
-                self.send_command("S14"),
-            )
-        else:
-            _LOGGER.debug("Requesting state update from server (S00, S14)")
-            await asyncio.gather(
-                # List unsealed Zones
-                self.send_command("S00"),
-                # Arming status update
-                self.send_command("S14"),
-            )
+        _LOGGER.debug("Requesting state update from server (S00, S20, S14)")
+        await asyncio.gather(
+            # List unsealed Zones 1-16
+            self.send_command("S00"),
+            # List unsealed Zones 17-32
+            # Note: Request this for all panels. Many panels can exceed 16 zones
+            # via expansion modules, but the ASCII protocol does not provide a
+            # reliable way to detect expansion presence. Panels tested tolerate
+            # S20 when only 8/16 zones are configured and simply return an empty
+            # set for zones 17–32. The extra status request is negligible
+            # overhead and guarantees we observe zones 17–32 whenever they exist.
+            self.send_command("S20"),
+            # Arming status update
+            self.send_command("S14"),
+        )
 
     async def _probe_panel_model(self) -> None:
         _LOGGER.debug("Requesting panel model probe from server (S17)")

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -5,7 +5,6 @@ from asyncio import sleep
 from typing import Callable, Dict
 
 from justbackoff import Backoff
-
 from .alarm import ArmingState, Alarm, ArmingMode
 from .connection import Connection, IP232Connection, Serial232Connection
 from .event import BaseEvent, DecodeOptions, StatusUpdate

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -5,6 +5,7 @@ from asyncio import sleep
 from typing import Callable, Dict
 
 from justbackoff import Backoff
+
 from .alarm import ArmingState, Alarm, ArmingMode
 from .connection import Connection, IP232Connection, Serial232Connection
 from .event import BaseEvent, DecodeOptions, StatusUpdate

--- a/nessclient/event.py
+++ b/nessclient/event.py
@@ -548,7 +548,6 @@ class PanelVersionUpdate(StatusUpdate):
         # DPlus panel variants
         DPLUS8 = "DPLUS8"
 
-
     """Panel model and modem combinations prior to documentation revision 16.
 
     Previous documentation revisions did not specify explicit examples beyond:

--- a/nessclient/event.py
+++ b/nessclient/event.py
@@ -141,25 +141,42 @@ class SystemStatusEvent(BaseEvent):
 
 class StatusUpdate(BaseEvent):
     class RequestID(Enum):
-        ZONE_INPUT_UNSEALED = 0x0
-        ZONE_RADIO_UNSEALED = 0x1
-        ZONE_CBUS_UNSEALED = 0x2
-        ZONE_IN_DELAY = 0x3
-        ZONE_IN_DOUBLE_TRIGGER = 0x4
-        ZONE_IN_ALARM = 0x5
-        ZONE_EXCLUDED = 0x6
-        ZONE_AUTO_EXCLUDED = 0x7
-        ZONE_SUPERVISION_FAIL_PENDING = 0x8
-        ZONE_SUPERVISION_FAIL = 0x9
-        ZONE_DOORS_OPEN = 0x10
-        ZONE_DETECTOR_LOW_BATTERY = 0x11
-        ZONE_DETECTOR_TAMPER = 0x12
+        ZONE_1_16_INPUT_UNSEALED = 0x0
+        ZONE_1_16_RADIO_UNSEALED = 0x1
+        ZONE_1_16_CBUS_UNSEALED = 0x2
+        ZONE_1_16_IN_DELAY = 0x3
+        ZONE_1_16_IN_DOUBLE_TRIGGER = 0x4
+        ZONE_1_16_IN_ALARM = 0x5
+        ZONE_1_16_EXCLUDED = 0x6
+        ZONE_1_16_AUTO_EXCLUDED = 0x7
+        ZONE_1_16_SUPERVISION_FAIL_PENDING = 0x8
+        ZONE_1_16_SUPERVISION_FAIL = 0x9
+        ZONE_1_16_DOORS_OPEN = 0x10
+        ZONE_1_16_DETECTOR_LOW_BATTERY = 0x11
+        ZONE_1_16_DETECTOR_TAMPER = 0x12
         MISCELLANEOUS_ALARMS = 0x13
         ARMING = 0x14
         OUTPUTS = 0x15
         VIEW_STATE = 0x16
         PANEL_VERSION = 0x17
         AUXILIARY_OUTPUTS = 0x18
+        ZONE_1_16_EXCLUDED_PLUS_AUTO_EXCLUDED = 0x19
+        # DPLUS 32-zone panels introduce parallel request IDs for zones 17–32.
+        # Values follow the spec IDs directly as hex.
+        ZONE_17_32_INPUT_UNSEALED = 0x20
+        ZONE_17_32_RADIO_UNSEALED = 0x21
+        ZONE_17_32_CBUS_UNSEALED = 0x22
+        ZONE_17_32_IN_DELAY = 0x23
+        ZONE_17_32_IN_DOUBLE_TRIGGER = 0x24
+        ZONE_17_32_IN_ALARM = 0x25
+        ZONE_17_32_EXCLUDED = 0x26
+        ZONE_17_32_AUTO_EXCLUDED = 0x27
+        ZONE_17_32_SUPERVISION_FAIL_PENDING = 0x28
+        ZONE_17_32_SUPERVISION_FAIL = 0x29
+        ZONE_17_32_DOORS_OPEN = 0x30
+        ZONE_17_32_DETECTOR_LOW_BATTERY = 0x31
+        ZONE_17_32_DETECTOR_TAMPER = 0x32
+        ZONE_17_32_EXCLUDED_PLUS_AUTO_EXCLUDED = 0x33
 
     def __init__(
         self,
@@ -175,8 +192,10 @@ class StatusUpdate(BaseEvent):
         self, packet: Packet, options: DecodeOptions | None = None
     ) -> "StatusUpdate":
         request_id = StatusUpdate.RequestID(int(packet.data[0:2], 16))
-        if request_id.name.startswith("ZONE"):
-            return ZoneUpdate.decode(packet, options)
+        if request_id.name.startswith("ZONE_1_16"):
+            return ZoneUpdate_1_16.decode(packet, options)
+        elif request_id.name.startswith("ZONE_17_32"):
+            return ZoneUpdate_17_32.decode(packet, options)
         elif request_id == StatusUpdate.RequestID.MISCELLANEOUS_ALARMS:
             return MiscellaneousAlarmsUpdate.decode(packet, options)
         elif request_id == StatusUpdate.RequestID.ARMING:
@@ -193,7 +212,7 @@ class StatusUpdate(BaseEvent):
             raise ValueError("Unhandled request_id case: {}".format(request_id))
 
 
-class ZoneUpdate(StatusUpdate):
+class ZoneUpdate_1_16(StatusUpdate):
     class Zone(Enum):
         ZONE_1 = 0x0100
         ZONE_2 = 0x0200
@@ -214,22 +233,82 @@ class ZoneUpdate(StatusUpdate):
 
     def __init__(
         self,
-        included_zones: List["ZoneUpdate.Zone"],
+        included_zones: List["ZoneUpdate_1_16.Zone"],
         request_id: "StatusUpdate.RequestID",
         address: int | None,
         timestamp: datetime.datetime | None,
     ) -> None:
-        super(ZoneUpdate, self).__init__(
+        super(ZoneUpdate_1_16, self).__init__(
             request_id=request_id, address=address, timestamp=timestamp
         )
         self.included_zones = included_zones
 
     @classmethod
-    def decode(cls, packet: Packet, options: DecodeOptions | None = None) -> "ZoneUpdate":
+    def decode(
+        cls, packet: Packet, options: DecodeOptions | None = None
+    ) -> "ZoneUpdate_1_16":
         request_id = StatusUpdate.RequestID(int(packet.data[0:2], 16))
-        return ZoneUpdate(
+        return ZoneUpdate_1_16(
             request_id=request_id,
-            included_zones=unpack_unsigned_short_data_enum(packet, ZoneUpdate.Zone),
+            included_zones=unpack_unsigned_short_data_enum(packet, ZoneUpdate_1_16.Zone),
+            timestamp=packet.timestamp,
+            address=packet.address,
+        )
+
+    def encode(self) -> Packet:
+        data = "{:02x}{}".format(
+            self.request_id.value,
+            pack_unsigned_short_data_enum(self.included_zones),
+        )
+        return Packet(
+            address=self.address,
+            seq=0x00,
+            command=CommandType.USER_INTERFACE,
+            data=data,
+            timestamp=None,
+            is_user_interface_resp=True,
+        )
+
+
+class ZoneUpdate_17_32(StatusUpdate):
+    class Zone(Enum):
+        ZONE_17 = 0x0100
+        ZONE_18 = 0x0200
+        ZONE_19 = 0x0400
+        ZONE_20 = 0x0800
+        ZONE_21 = 0x1000
+        ZONE_22 = 0x2000
+        ZONE_23 = 0x4000
+        ZONE_24 = 0x8000
+        ZONE_25 = 0x0001
+        ZONE_26 = 0x0002
+        ZONE_27 = 0x0004
+        ZONE_28 = 0x0008
+        ZONE_29 = 0x0010
+        ZONE_30 = 0x0020
+        ZONE_31 = 0x0040
+        ZONE_32 = 0x0080
+
+    def __init__(
+        self,
+        included_zones: List["ZoneUpdate_17_32.Zone"],
+        request_id: "StatusUpdate.RequestID",
+        address: int | None,
+        timestamp: datetime.datetime | None,
+    ) -> None:
+        super(ZoneUpdate_17_32, self).__init__(
+            request_id=request_id, address=address, timestamp=timestamp
+        )
+        self.included_zones = included_zones
+
+    @classmethod
+    def decode(
+        cls, packet: Packet, options: DecodeOptions | None = None
+    ) -> "ZoneUpdate_17_32":
+        request_id = StatusUpdate.RequestID(int(packet.data[0:2], 16))
+        return ZoneUpdate_17_32(
+            request_id=request_id,
+            included_zones=unpack_unsigned_short_data_enum(packet, ZoneUpdate_17_32.Zone),
             timestamp=packet.timestamp,
             address=packet.address,
         )

--- a/nessclient_tests/test_alarm.py
+++ b/nessclient_tests/test_alarm.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from nessclient.alarm import Alarm, ArmingState, ArmingMode
-from nessclient.event import ArmingUpdate, ZoneUpdate, SystemStatusEvent
+from nessclient.event import ArmingUpdate, ZoneUpdate_1_16, SystemStatusEvent
 
 
 def test_state_is_initially_unknown(alarm):
@@ -15,16 +15,16 @@ def test_zones_are_initially_unknown(alarm):
         assert zone.triggered is None
 
 
-def test_16_zones_are_created(alarm):
-    assert len(alarm.zones) == 16
+def test_32_zones_are_created(alarm):
+    assert len(alarm.zones) == 32
 
 
 def test_handle_event_zone_update(alarm):
-    event = ZoneUpdate(
-        included_zones=[ZoneUpdate.Zone.ZONE_1, ZoneUpdate.Zone.ZONE_3],
+    event = ZoneUpdate_1_16(
+        included_zones=[ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
         timestamp=None,
         address=None,
-        request_id=ZoneUpdate.RequestID.ZONE_INPUT_UNSEALED,
+        request_id=ZoneUpdate_1_16.RequestID.ZONE_1_16_INPUT_UNSEALED,
     )
     alarm.handle_event(event)
     assert alarm.zones[0].triggered is True
@@ -36,11 +36,11 @@ def test_handle_event_zone_update_sealed(alarm):
     alarm.zones[0].triggered = True
     alarm.zones[1].triggered = True
 
-    event = ZoneUpdate(
-        included_zones=[ZoneUpdate.Zone.ZONE_1, ZoneUpdate.Zone.ZONE_3],
+    event = ZoneUpdate_1_16(
+        included_zones=[ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
         timestamp=None,
         address=None,
-        request_id=ZoneUpdate.RequestID.ZONE_INPUT_UNSEALED,
+        request_id=ZoneUpdate_1_16.RequestID.ZONE_1_16_INPUT_UNSEALED,
     )
     alarm.handle_event(event)
     assert alarm.zones[0].triggered is True
@@ -55,11 +55,11 @@ def test_handle_event_zone_update_callback(alarm):
 
     cb = Mock()
     alarm.on_zone_change(cb)
-    event = ZoneUpdate(
-        included_zones=[ZoneUpdate.Zone.ZONE_1, ZoneUpdate.Zone.ZONE_3],
+    event = ZoneUpdate_1_16(
+        included_zones=[ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
         timestamp=None,
         address=None,
-        request_id=ZoneUpdate.RequestID.ZONE_INPUT_UNSEALED,
+        request_id=ZoneUpdate_1_16.RequestID.ZONE_1_16_INPUT_UNSEALED,
     )
     alarm.handle_event(event)
     assert cb.call_count == 3

--- a/nessclient_tests/test_alarm.py
+++ b/nessclient_tests/test_alarm.py
@@ -75,7 +75,7 @@ def test_handle_event_zone_update_1_16_callback(alarm):
 
 def test_handle_event_zone_update_1_16_does_not_affect_17_32(alarm):
     # Seed some 17–32 states
-    alarm.zones[16].triggered = True   # zone 17
+    alarm.zones[16].triggered = True  # zone 17
     alarm.zones[20].triggered = False  # zone 21
 
     # Apply a 1–16 update
@@ -154,7 +154,7 @@ def test_handle_event_zone_update_17_32_callback(alarm):
 
 def test_handle_event_zone_update_17_32_does_not_affect_1_16(alarm):
     # Seed some 1–16 states
-    alarm.zones[0].triggered = True   # zone 1
+    alarm.zones[0].triggered = True  # zone 1
     alarm.zones[5].triggered = False  # zone 6
 
     # Apply a 17–32 update

--- a/nessclient_tests/test_client.py
+++ b/nessclient_tests/test_client.py
@@ -92,9 +92,7 @@ async def test_get_panel_info_cached_returns_without_io(
     connection, client: Client, alarm: Alarm
 ):
     # If panel_info is already known, get_panel_info returns it and performs no I/O
-    alarm.panel_info = PanelInfo(  # type: ignore[attr-defined]
-        model=PanelVersionUpdate.Model.D16X, version="8.7"
-    )
+    alarm.panel_info = PanelInfo(model=PanelVersionUpdate.Model.D16X, version="8.7")
 
     info = await client.get_panel_info()
     assert info.model == PanelVersionUpdate.Model.D16X
@@ -108,7 +106,7 @@ async def test_get_panel_info_probes_when_missing(
     connection, client: Client, alarm: Alarm
 ):
     # With no cached info, get_panel_info should send S17 and return parsed info
-    alarm.panel_info = None  # type: ignore[attr-defined]
+    alarm.panel_info = None
 
     # Patch send_command_and_wait to send S17 then return a PanelVersionUpdate
     orig_send_command = client.send_command

--- a/nessclient_tests/test_client.py
+++ b/nessclient_tests/test_client.py
@@ -79,22 +79,12 @@ async def test_update(connection, client: Client, alarm: Alarm):
     # Update should send S00, S20 and S14
     await client.update()
     assert connection.write.call_count == 3
-    followup = {
+    commands = {
         get_data(connection.write.call_args_list[0][0][0]),
         get_data(connection.write.call_args_list[1][0][0]),
         get_data(connection.write.call_args_list[2][0][0]),
     }
-    assert followup == {b"S00", b"S20", b"S14"}
-
-    # Subsequent updates should send S00, S20 and S14 again
-    await client.update()
-    assert connection.write.call_count == 6
-    followup2 = {
-        get_data(connection.write.call_args_list[3][0][0]),
-        get_data(connection.write.call_args_list[4][0][0]),
-        get_data(connection.write.call_args_list[5][0][0]),
-    }
-    assert followup2 == {b"S00", b"S20", b"S14"}
+    assert commands == {b"S00", b"S20", b"S14"}
 
 
 @pytest.mark.asyncio

--- a/nessclient_tests/test_client.py
+++ b/nessclient_tests/test_client.py
@@ -129,61 +129,6 @@ async def test_get_panel_info_probes_when_missing(
     assert info.version == "8.7"
 
 
-def panel_version_response(
-    model: PanelVersionUpdate.Model,
-    major: int = 8,
-    minor: int = 7,
-) -> PanelVersionUpdate:
-    """Construct a PanelVersionUpdate event for PANEL_VERSION (S17)."""
-    return PanelVersionUpdate(
-        model=model,
-        major_version=major,
-        minor_version=minor,
-        address=0x00,
-        timestamp=None,
-    )
-
-
-@pytest.mark.asyncio
-async def test_get_panel_info_cached_returns_without_io(
-    connection, client: Client, alarm: Alarm
-):
-    # If panel_info is already known, get_panel_info returns it and performs no I/O
-    alarm.panel_info = PanelInfo(model=PanelVersionUpdate.Model.D16X, version="8.7")
-
-    info = await client.get_panel_info()
-    assert info.model == PanelVersionUpdate.Model.D16X
-    assert info.version == "8.7"
-    # No writes should have occurred
-    assert connection.write.call_count == 0
-
-
-@pytest.mark.asyncio
-async def test_get_panel_info_probes_when_missing(
-    connection, client: Client, alarm: Alarm
-):
-    # With no cached info, get_panel_info should send S17 and return parsed info
-    alarm.panel_info = None
-
-    # Patch send_command_and_wait to send S17 then return a PanelVersionUpdate
-    orig_send_command = client.send_command
-
-    async def fake_scaw(command: str, timeout: float | None = 5.0):
-        await orig_send_command(command)
-        return panel_version_response(PanelVersionUpdate.Model.D32X, 8, 7)
-
-    client.send_command_and_wait = fake_scaw  # type: ignore[assignment]
-
-    info = await client.get_panel_info()
-    # Ensure S17 was sent
-    assert connection.write.call_count == 1
-    first = get_data(connection.write.call_args_list[0][0][0])
-    assert first == b"S17"
-    # Info returned should match the fake response
-    assert info.model == PanelVersionUpdate.Model.D32X
-    assert info.version == "8.7"
-
-
 @pytest.mark.asyncio
 async def test_send_command(connection, client):
     await client.send_command("ABCDEFGHI")

--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -266,7 +266,7 @@ class SystemStatusEventTestCase(unittest.TestCase):
         self.assertEqual(event.zone, 0)
         self.assertEqual(event.type, SystemStatusEvent.EventType.EXIT_DELAY_END)
 
-    def test_zone_sealed(self):
+    def test_zone_sealed_with_zone_5(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "010500")
         event = SystemStatusEvent.decode(pkt)
         self.assertEqual(event.area, 0)
@@ -285,6 +285,48 @@ class SystemStatusEventTestCase(unittest.TestCase):
         event = SystemStatusEvent.decode(pkt)
         self.assertEqual(event.area, 0)
         self.assertEqual(event.zone, 16)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
+
+    def test_zone_sealed_with_zone_17_in_area_1(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "011701")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 17)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.SEALED)
+
+    def test_zone_unsealed_with_zone_17_in_area_1(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "001701")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 17)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
+
+    def test_zone_sealed_with_zone_17(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "011700")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 17)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.SEALED)
+
+    def test_zone_unsealed_with_zone_17(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "001700")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 17)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
+
+    def test_zone_sealed_with_zone_32(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "013200")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 32)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.SEALED)
+
+    def test_zone_unsealed_with_zone_32(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "003200")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 32)
         self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
 
     def test_zone_alarm_with_zone_5_area_1(self):

--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -2,7 +2,7 @@ import unittest
 from typing import cast
 
 from nessclient.event import (
-    ZoneUpdate,
+    ZoneUpdate_1_16,
     pack_unsigned_short_data_enum,
     ArmingUpdate,
     StatusUpdate,
@@ -20,7 +20,7 @@ from nessclient.packet import Packet, CommandType
 
 class UtilsTestCase(unittest.TestCase):
     def test_pack_unsigned_short_data_enum(self):
-        value = [ZoneUpdate.Zone.ZONE_1, ZoneUpdate.Zone.ZONE_4]
+        value = [ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_4]
         self.assertEqual(
             "0900",
             pack_unsigned_short_data_enum(value),
@@ -47,7 +47,7 @@ class StatusUpdateTestCase(unittest.TestCase):
     def test_decode_zone_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "000000")
         event = StatusUpdate.decode(pkt)
-        self.assertTrue(isinstance(event, ZoneUpdate))
+        self.assertTrue(isinstance(event, ZoneUpdate_1_16))
 
     def test_decode_misc_alarms_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "130000")
@@ -110,9 +110,9 @@ class ArmingUpdateTestCase(unittest.TestCase):
 
 class ZoneUpdateTestCase(unittest.TestCase):
     def test_encode(self):
-        event = ZoneUpdate(
-            included_zones=[ZoneUpdate.Zone.ZONE_1, ZoneUpdate.Zone.ZONE_3],
-            request_id=StatusUpdate.RequestID.ZONE_INPUT_UNSEALED,
+        event = ZoneUpdate_1_16(
+            included_zones=[ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
+            request_id=StatusUpdate.RequestID.ZONE_1_16_INPUT_UNSEALED,
             timestamp=None,
             address=0x00,
         )
@@ -123,24 +123,26 @@ class ZoneUpdateTestCase(unittest.TestCase):
 
     def test_zone_in_delay_no_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "030000")
-        event = ZoneUpdate.decode(pkt)
-        self.assertEqual(event.request_id, ZoneUpdate.RequestID.ZONE_IN_DELAY)
+        event = ZoneUpdate_1_16.decode(pkt)
+        self.assertEqual(event.request_id, ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_DELAY)
         self.assertEqual(event.included_zones, [])
 
     def test_zone_in_delay_with_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "030500")
-        event = ZoneUpdate.decode(pkt)
-        self.assertEqual(event.request_id, ZoneUpdate.RequestID.ZONE_IN_DELAY)
+        event = ZoneUpdate_1_16.decode(pkt)
+        self.assertEqual(event.request_id, ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_DELAY)
         self.assertEqual(
-            event.included_zones, [ZoneUpdate.Zone.ZONE_1, ZoneUpdate.Zone.ZONE_3]
+            event.included_zones,
+            [ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
         )
 
     def test_zone_in_alarm_with_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "051400")
-        event = ZoneUpdate.decode(pkt)
-        self.assertEqual(event.request_id, ZoneUpdate.RequestID.ZONE_IN_ALARM)
+        event = ZoneUpdate_1_16.decode(pkt)
+        self.assertEqual(event.request_id, ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_ALARM)
         self.assertEqual(
-            event.included_zones, [ZoneUpdate.Zone.ZONE_3, ZoneUpdate.Zone.ZONE_5]
+            event.included_zones,
+            [ZoneUpdate_1_16.Zone.ZONE_3, ZoneUpdate_1_16.Zone.ZONE_5],
         )
 
 

--- a/nessclient_tests/test_packet.py
+++ b/nessclient_tests/test_packet.py
@@ -158,3 +158,41 @@ class PacketTestCase(unittest.TestCase):
         event = BaseEvent.decode(pkt)
         print(pkt)
         print(event)
+
+    def test_decode_status_update_response_zone_17_32_none(self):
+        # Zone 17-32 Input Unsealed (ID 0x20), no zones set
+        pkt = Packet.decode("82000360200000ff")
+        self.assertEqual(pkt.start, 0x82)
+        self.assertEqual(pkt.address, 0x00)
+        self.assertEqual(pkt.length, 3)
+        self.assertEqual(pkt.seq, 0x00)
+        self.assertEqual(pkt.command, CommandType.USER_INTERFACE)
+        self.assertEqual(pkt.data, "200000")
+        self.assertIsNone(pkt.timestamp)
+        self.assertTrue(pkt.is_user_interface_resp)
+
+    def test_decode_status_update_response_zone_17_32_in_alarm_zone17(self):
+        # Zone 17-32 In Alarm (ID 0x25), Zone 17 set
+        pkt = Packet.decode("82000360250100aa")
+        self.assertEqual(pkt.data, "250100")
+        self.assertTrue(pkt.is_user_interface_resp)
+
+    def test_decode_status_update_response_zone_23_unsealed_example(self):
+        # From FORM 5 examples in the spec (address 0x07)
+        # Example: Zone 23 unseal (ID 0x20, data 0x4000)
+        pkt = Packet.decode("8207036020400013")
+        self.assertEqual(pkt.start, 0x82)
+        self.assertEqual(pkt.address, 0x07)
+        self.assertEqual(pkt.length, 3)
+        self.assertEqual(pkt.seq, 0x00)
+        self.assertEqual(pkt.command, CommandType.USER_INTERFACE)
+        self.assertEqual(pkt.data, "204000")
+        self.assertTrue(pkt.is_user_interface_resp)
+
+    def test_decode_status_update_response_zone_23_24_unsealed_example(self):
+        # From FORM 5 examples in the spec (address 0x07)
+        # Example: Zones 23 and 24 unseal (ID 0x20, data 0xC000)
+        pkt = Packet.decode("8207036020c00054")
+        self.assertEqual(pkt.address, 0x07)
+        self.assertEqual(pkt.data, "20c000")
+        self.assertTrue(pkt.is_user_interface_resp)


### PR DESCRIPTION
**Summary**
- Adds end-to-end 32‑zone support (D8/D16 with expanders and D32X/DPlus) across client, events, dummy server, and TUI.

**Key Changes**
- Client: always requests `S20` in `Client.update()` (alongside `S00` and `S14`) to capture zones 17–32; safe on ≤16‑zone panels which respond empty.
- Events: splits prior `ZoneUpdate` into `ZoneUpdate_1_16` and new `ZoneUpdate_17_32`; extends `StatusUpdate.RequestID` with 0x20–0x33 IDs.
- Alarm: exposes 32 zones by default; handles both 1–16 and 17–32 updates independently; tracks `panel_info`.
- Client: adds `get_panel_info()` which probes `S17` and returns cached `PanelInfo` on subsequent calls.
- CLI server: adds `--zones` (1–32) to simulate any panel size; responds to `S00` (1–16) and `S20` (17–32) accordingly.
- CLI: events and TUI probe and print panel info using `get_panel_info()`.
- Docs: README notes server `--zones` behavior and how `S00`/`S20` map to zone banks.
- Tests: comprehensive coverage for 17–32 paths in packets, event decode/encode, alarm state, and client behavior.

**Compatibility Notes**
- API rename: `ZoneUpdate` is now `ZoneUpdate_1_16`. New class `ZoneUpdate_17_32` models the upper bank. Downstream imports using `ZoneUpdate` should switch to `ZoneUpdate_1_16`.
- Alarm: `Alarm.zones` now has length 32. Code assuming exactly 16 should be updated to handle 32 or consider the first 16 as needed.
- Protocol usage: Unconditionally issuing `S20` is compatible with ≤16‑zone panels (observed to return an empty set); this ensures correct behavior when expanders are present.

**Testing**
- New and updated tests in `nessclient_tests/` validate:
  - Event decoding/encoding for IDs 0x20–0x33.
  - Alarm update logic for both zone banks and callback behavior.
  - Client update sends `S00`, `S20`, `S14`; `get_panel_info()` probes `S17` once and then uses cache.
- Run: `uv run pytest` (plus style/type checks per repo guidelines).

**Docs/CLI**
- README: adds "Server zones" with `--zones` examples and explains `S00` vs `S20`.
- CLI server: `ness-cli server --zones N --panel-model ...` simulates desired size irrespective of model.

**Why this change**
- Aligns implementation with the D8‑32X protocol where zones 17–32 use parallel request IDs. Ensures clients correctly reflect upper‑bank zone states and makes development/testing easier via the enhanced dummy server.
