### PR TITLE
feat(client): awaitable USER_INTERFACE (SXX) requests via send_command_and_wait

### DIFF
--- a/examples/sending_commands.py
+++ b/examples/sending_commands.py
@@ -1,28 +1,38 @@
 import asyncio
+import contextlib
 
 from nessclient import Client
 
-loop = asyncio.get_event_loop()
-host = "127.0.0.1"
-port = 65432
-client = Client(host=host, port=port)
 
-# Send arming command via library abstraction
-loop.run_until_complete(client.arm_away("1234"))
-# Send panic command via library abstraction
-loop.run_until_complete(client.panic("1234"))
-# Send disarm command via library abstraction
-loop.run_until_complete(client.disarm("1234"))
-# Send aux control command for output 2 via library abstraction
-loop.run_until_complete(client.aux(2))
-# Send custom command
-# In this instance, we are sending a status update command to view
-# output status
-loop.run_until_complete(client.send_command("S15"))
+async def main() -> None:
+    host = "127.0.0.1"
+    port = 65432
+    client = Client(host=host, port=port)
+    # Run background loops so responses are received while awaiting
+    keepalive_task = asyncio.create_task(client.keepalive())
+    try:
+        # # Send arming command via library abstraction
+        # await client.arm_away("1234")
+        # # Send panic command via library abstraction
+        # await client.panic("1234")
+        # # Send disarm command via library abstraction
+        # await client.disarm("1234")
+        # # Send aux control command for output 2 via library abstraction
+        # await client.aux(2)
+        # # Send custom command
+        # # In this instance, we are sending a status update command to view
+        # # output status
+        # await client.send_command("S15")
 
-# Await a status request and receive the decoded response
-resp = loop.run_until_complete(client.send_command_and_wait("S14", timeout=5.0))
-print("Arming status response:", resp)
+        # Await a status request and receive the decoded response
+        resp = await client.send_command_and_wait("S14", timeout=5.0)
+        print("Arming status response:", resp)
+    finally:
+        await client.close()
+        keepalive_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await keepalive_task
 
-client.close()
-loop.close()
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/sending_commands.py
+++ b/examples/sending_commands.py
@@ -20,5 +20,9 @@ loop.run_until_complete(client.aux(2))
 # output status
 loop.run_until_complete(client.send_command("S15"))
 
+# Await a status request and receive the decoded response
+resp = loop.run_until_complete(client.send_command_and_wait("S14", timeout=5.0))
+print("Arming status response:", resp)
+
 client.close()
 loop.close()

--- a/examples/sending_commands.py
+++ b/examples/sending_commands.py
@@ -11,20 +11,20 @@ async def main() -> None:
     # Run background loops so responses are received while awaiting
     keepalive_task = asyncio.create_task(client.keepalive())
     try:
-        # # Send arming command via library abstraction
-        # await client.arm_away("1234")
-        # # Send panic command via library abstraction
-        # await client.panic("1234")
-        # # Send disarm command via library abstraction
-        # await client.disarm("1234")
-        # # Send aux control command for output 2 via library abstraction
-        # await client.aux(2)
-        # # Send custom command
-        # # In this instance, we are sending a status update command to view
-        # # output status
-        # await client.send_command("S15")
-
-        # Await a status request and receive the decoded response
+        # Send arming command via library abstraction
+        await client.arm_away("1234")
+        # Send panic command via library abstraction
+        await client.panic("1234")
+        # Send disarm command via library abstraction
+        await client.disarm("1234")
+        # Send aux control command for output 2 via library abstraction
+        await client.aux(2)
+        # Send custom command
+        # In this instance, we are sending a status update command to view
+        # output status
+        await client.send_command("S15")
+        # Send and await a status request to receive the decoded response
+        # note: the background keepalive must be running for this to work
         resp = await client.send_command_and_wait("S14", timeout=5.0)
         print("Arming status response:", resp)
     finally:

--- a/nessclient_tests/test_client.py
+++ b/nessclient_tests/test_client.py
@@ -5,6 +5,9 @@ import pytest
 from nessclient import Client
 from nessclient.alarm import Alarm
 from nessclient.connection import Connection
+from nessclient.event import StatusUpdate, BaseEvent
+from nessclient.packet import Packet, CommandType
+import asyncio
 
 
 def get_data(pkt: bytes) -> bytes:
@@ -124,6 +127,89 @@ def test_on_zone_change_callback_is_registered(client, alarm):
 async def test_close(connection, client):
     await client.close()
     assert connection.close.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_send_command_and_wait_sends_payload(connection, client):
+    # Start, allow send to occur
+    task = asyncio.create_task(client.send_command_and_wait("S14", timeout=1.0))
+    await asyncio.sleep(0)
+    # Verify write and payload
+    assert connection.write.call_count == 1
+    assert get_data(connection.write.call_args[0][0]) == b"S14"
+    # Complete the task by dispatching a matching response (no assertions here)
+    pkt = Packet(
+        address=0x00,
+        seq=0x00,
+        command=CommandType.USER_INTERFACE,
+        data="140000",
+        timestamp=None,
+        is_user_interface_resp=True,
+    )
+    client._dispatch_event(BaseEvent.decode(pkt), pkt)
+    await task
+
+
+@pytest.mark.asyncio
+async def test_send_command_and_wait_resolves_on_response(connection, client):
+    task = asyncio.create_task(client.send_command_and_wait("S14", timeout=1.0))
+    # Allow registration of the waiter
+    await asyncio.sleep(0)
+    # Simulate incoming USER_INTERFACE response for request id 14
+    pkt = Packet(
+        address=0x00,
+        seq=0x00,
+        command=CommandType.USER_INTERFACE,
+        data="140000",
+        timestamp=None,
+        is_user_interface_resp=True,
+    )
+    event = BaseEvent.decode(pkt)
+    client._dispatch_event(event, pkt)
+    result = await task
+    assert isinstance(result, StatusUpdate)
+    assert result.request_id == StatusUpdate.RequestID.ARMING
+
+
+@pytest.mark.asyncio
+async def test_send_command_and_wait_times_out(connection, client):
+    with pytest.raises(asyncio.TimeoutError):
+        await client.send_command_and_wait("S14", timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_send_command_and_wait_raises_for_non_status(connection, client):
+    with pytest.raises(ValueError):
+        await client.send_command_and_wait("A1234E", timeout=0.01)
+
+
+@pytest.mark.asyncio
+async def test_multiple_waiters_resolve_together(connection, client):
+    # Two concurrent S14 waits
+    t1 = asyncio.create_task(client.send_command_and_wait("S14", timeout=1.0))
+    t2 = asyncio.create_task(client.send_command_and_wait("S14", timeout=1.0))
+
+    # Ensure two commands were sent
+    await asyncio.sleep(0)
+    assert connection.write.call_count == 2
+
+    # Single response should resolve both waiters
+    pkt = Packet(
+        address=0x00,
+        seq=0x00,
+        command=CommandType.USER_INTERFACE,
+        data="140001",
+        timestamp=None,
+        is_user_interface_resp=True,
+    )
+    e = BaseEvent.decode(pkt)
+    client._dispatch_event(e, pkt)
+
+    r1 = await t1
+    r2 = await t2
+    assert isinstance(r1, StatusUpdate) and isinstance(r2, StatusUpdate)
+    assert r1.request_id == StatusUpdate.RequestID.ARMING
+    assert r2.request_id == StatusUpdate.RequestID.ARMING
 
 
 @pytest.fixture


### PR DESCRIPTION
Adds an opt-in, awaitable path for USER_INTERFACE status requests (SXX), without changing the existing `send_command` API.

Summary
- New `Client.send_command_and_wait(command, timeout=5.0) -> StatusUpdate`:
  - Sends the provided command verbatim.
  - Requires an SXX status request; raises `ValueError` for commands that do not elicit a status reply.
  - Awaits the first matching USER_INTERFACE response and returns the decoded `StatusUpdate` (with timeout).
- Request tracking:
  - Tracks a single shared `Future` per request ID and resolves all concurrent waiters together on the first matching response.
  - Avoids race conditions while staying simple, since a single status update typically answers all pending identical requests.
- No changes to `send_command` API or behavior.

Tests
- Added coverage for:
  - payload correctness when sending SXX
  - successful resolve on response
  - timeout behavior
  - `ValueError` for non-status commands
  - multiple concurrent waiters for the same SXX resolving together
- Current suite: 105 tests passing locally.

Examples
- Extended existing examples to demonstrate awaiting:
  - `examples/sending_commands.py`: shows `send_command_and_wait("S14")`
  - `examples/listening_for_events.py`: demonstrates awaiting within `asyncio.gather`

Housekeeping
- Removed README snippet for awaitable usage; examples now show it instead.
- Verified formatting (ruff), linting (ruff), types (mypy --strict), tests (pytest) all pass.

Requested review
- API surface and naming (`send_command_and_wait`)—does it read clearly alongside `send_command`?
- Behavior for multiple concurrent SXX: resolving all waiters on first response matches the intended semantics.
