### PR TITLE
refactor: use asyncio.run in example

### DIFF
--- a/examples/listening_for_events.py
+++ b/examples/listening_for_events.py
@@ -2,33 +2,32 @@ import asyncio
 
 from nessclient import Client, ArmingState, ArmingMode, BaseEvent
 
-loop = asyncio.get_event_loop()
-host = "127.0.0.1"
-port = 65432
-client = Client(host=host, port=port)
+
+async def main() -> None:
+    host = "127.0.0.1"
+    port = 65432
+    client = Client(host=host, port=port)
+
+    @client.on_zone_change
+    def on_zone_change(zone: int, triggered: bool) -> None:
+        print("Zone {} changed to {}".format(zone, triggered))
+
+    @client.on_state_change
+    def on_state_change(state: ArmingState, _arming_mode: ArmingMode | None) -> None:
+        print("Alarm state changed to {}".format(state))
+
+    @client.on_event_received
+    def on_event_received(event: BaseEvent) -> None:
+        print("Event received:", event)
+
+    try:
+        await asyncio.gather(
+            client.keepalive(),
+            client.update(),
+        )
+    finally:
+        client.close()
 
 
-@client.on_zone_change
-def on_zone_change(zone: int, triggered: bool):
-    print("Zone {} changed to {}".format(zone, triggered))
-
-
-@client.on_state_change
-def on_state_change(state: ArmingState, _arming_mode: ArmingMode | None):
-    print("Alarm state changed to {}".format(state))
-
-
-@client.on_event_received
-def on_event_received(event: BaseEvent):
-    print("Event received:", event)
-
-
-loop.run_until_complete(
-    asyncio.gather(
-        client.keepalive(),
-        client.update(),
-    )
-)
-
-client.close()
-loop.close()
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- replace deprecated `asyncio.get_event_loop` usage with `asyncio.run`

## Testing
- `uv sync --dev --all-extras`
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad8be47bd48331aac587252f77fcf3