### PR TITLE
Fix decimal zone encoding in SystemStatusEvent

### DIFF
--- a/nessclient/event.py
+++ b/nessclient/event.py
@@ -128,7 +128,7 @@ class SystemStatusEvent(BaseEvent):
         )
 
     def encode(self) -> Packet:
-        data = "{:02x}{:02x}{:02x}".format(self.type.value, self.zone, self.area)
+        data = "{:02x}{:02d}{:02x}".format(self.type.value, self.zone, self.area)
         return Packet(
             address=self.address,
             seq=0x00,


### PR DESCRIPTION
## Summary
- ensure SystemStatusEvent encodes zone as decimal instead of hex

## Testing
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad9fcdf2d48331ac2d3e0599d27815