### PR TITLE
feat: add packet logging to events CLI

### DIFF
--- a/nessclient/cli/events.py
+++ b/nessclient/cli/events.py
@@ -1,9 +1,13 @@
 import asyncio
+from typing import TextIO
+
 import click
 
+from ..alarm import ArmingMode, ArmingState
 from ..client import Client
-from ..alarm import ArmingState, ArmingMode
+from ..connection import IP232Connection, Serial232Connection
 from ..event import BaseEvent
+from .logging_connection import LoggingConnection
 from .server import DEFAULT_PORT
 
 
@@ -14,6 +18,7 @@ from .server import DEFAULT_PORT
 @click.option("--update-interval", type=int, default=60)
 @click.option("--infer-arming-state/--no-infer-arming-state")
 @click.option("--interactive", is_flag=True, help="Run with terminal UI")
+@click.option("--logfile", type=click.Path(), help="Write raw TX/RX packets to file")
 def events(
     host: str,
     port: int,
@@ -21,6 +26,7 @@ def events(
     infer_arming_state: bool,
     serial_tty: str | None,
     interactive: bool,
+    logfile: str | None,
 ) -> None:
     if interactive:
         from .tui import interactive_ui
@@ -32,15 +38,27 @@ def events(
                 update_interval=update_interval,
                 infer_arming_state=infer_arming_state,
                 serial_tty=serial_tty,
+                packet_logfile=logfile,
             )
         )
         return
 
+    log_fp: TextIO | None = open(logfile, "a") if logfile else None
+    connection = None
+    if log_fp is not None:
+        base_conn = (
+            IP232Connection(host=host, port=port)
+            if serial_tty is None
+            else Serial232Connection(tty_path=serial_tty)
+        )
+        connection = LoggingConnection(base_conn, log_fp)
+
     loop = asyncio.get_event_loop()
     client = Client(
-        host=host if serial_tty is None else None,
-        port=port if serial_tty is None else None,
-        serial_tty=serial_tty,
+        connection=connection,
+        host=host if connection is None and serial_tty is None else None,
+        port=port if connection is None and serial_tty is None else None,
+        serial_tty=serial_tty if connection is None else None,
         infer_arming_state=infer_arming_state,
         update_interval=update_interval,
     )

--- a/nessclient/cli/logging_connection.py
+++ b/nessclient/cli/logging_connection.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import TextIO
+
+from ..connection import Connection
+
+
+class LoggingConnection(Connection):
+    """Wrap a connection and log raw packet ASCII data."""
+
+    def __init__(self, inner: Connection, log_file: TextIO) -> None:
+        self._inner = inner
+        self._log_file = log_file
+
+    @property
+    def connected(self) -> bool:
+        return self._inner.connected
+
+    async def connect(self) -> bool:
+        return await self._inner.connect()
+
+    async def close(self) -> None:
+        await self._inner.close()
+
+    async def read(self) -> bytes | None:
+        data = await self._inner.read()
+        if data is not None:
+            try:
+                self._log_file.write(f"RX {data.decode('ascii').strip()}\n")
+                self._log_file.flush()
+            except Exception:
+                pass
+        return data
+
+    async def write(self, data: bytes) -> None:
+        try:
+            self._log_file.write(f"TX {data.decode('ascii').strip()}\n")
+            self._log_file.flush()
+        except Exception:
+            pass
+        await self._inner.write(data)


### PR DESCRIPTION
## Summary
- add `--logfile` option to events cli to record raw TX/RX packets
- support packet logging in interactive UI
- create `LoggingConnection` wrapper to log packets

## Testing
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad95ef5d808331b090bbdf9b67c55c