### PR TITLE
Add unit tests for 32‑zone status events

### DIFF
--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, List
+
 from .event import (
     BaseEvent,
     ZoneUpdate_1_16,

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, List
 
+from .event import PanelVersionUpdate
 from .event import (
     BaseEvent,
     ZoneUpdate_1_16,
@@ -52,7 +53,10 @@ class Alarm:
     def __init__(self, infer_arming_state: bool = False) -> None:
         self._infer_arming_state = infer_arming_state
         self.arming_state: ArmingState = ArmingState.UNKNOWN
-        self.zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(32)]
+        self._zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(32)]
+
+        self.panel_model: PanelVersionUpdate.Model | None = None
+        self.panel_version: str | None = None
 
         self._arming_mode: ArmingMode | None = None
 
@@ -60,6 +64,13 @@ class Alarm:
             None
         )
         self._on_zone_change: Callable[[int, bool], None] | None = None
+
+    @property
+    def zones(self) -> List[Zone]:
+        if self.panel_model == PanelVersionUpdate.Model.D32X:
+            return self._zones
+
+        return self._zones[:16]
 
     def handle_event(self, event: BaseEvent) -> None:
         if isinstance(event, ArmingUpdate):

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, List
 
-from .event import BaseEvent, ZoneUpdate, ArmingUpdate, SystemStatusEvent
+from .event import BaseEvent, ZoneUpdate_1_16, ZoneUpdate_17_32, ArmingUpdate, SystemStatusEvent
 
 
 class ArmingState(Enum):
@@ -46,7 +46,7 @@ class Alarm:
     def __init__(self, infer_arming_state: bool = False) -> None:
         self._infer_arming_state = infer_arming_state
         self.arming_state: ArmingState = ArmingState.UNKNOWN
-        self.zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(16)]
+        self.zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(32)]
 
         self._arming_mode: ArmingMode | None = None
 
@@ -59,10 +59,15 @@ class Alarm:
         if isinstance(event, ArmingUpdate):
             self._handle_arming_update(event)
         elif (
-            isinstance(event, ZoneUpdate)
-            and event.request_id == ZoneUpdate.RequestID.ZONE_INPUT_UNSEALED
+            isinstance(event, ZoneUpdate_1_16)
+            and event.request_id == ZoneUpdate_1_16.RequestID.ZONE_1_16_INPUT_UNSEALED
         ):
-            self._handle_zone_input_update(event)
+            self._handle_zone_1_16_input_update(event)
+        elif (
+                isinstance(event, ZoneUpdate_17_32)
+                and event.request_id == ZoneUpdate_17_32.RequestID.ZONE_17_32_INPUT_UNSEALED
+        ):
+            self._handle_zone_17_32_input_update(event)
         elif isinstance(event, SystemStatusEvent):
             self._handle_system_status_event(event)
 
@@ -95,14 +100,24 @@ class Alarm:
                 #  handles other arming modes.
                 return self._update_arming_state(ArmingState.DISARMED)
 
-    def _handle_zone_input_update(self, update: ZoneUpdate) -> None:
-        for i, zone in enumerate(self.zones):
+    def _handle_zone_1_16_input_update(self, update: ZoneUpdate_1_16) -> None:
+        for i, zone in enumerate(self.zones[:16]):
             zone_id = i + 1
             name = "ZONE_{}".format(zone_id)
-            if ZoneUpdate.Zone[name] in update.included_zones:
+            if ZoneUpdate_1_16.Zone[name] in update.included_zones:
                 self._update_zone(zone_id, True)
             else:
                 self._update_zone(zone_id, False)
+
+    def _handle_zone_17_32_input_update(self, update: ZoneUpdate_17_32) -> None:
+        for i, zone in enumerate(self.zones[16:]):
+            zone_id = i + 1
+            name = "ZONE_{}".format(zone_id)
+            if ZoneUpdate_17_32.Zone[name] in update.included_zones:
+                self._update_zone(zone_id, True)
+            else:
+                self._update_zone(zone_id, False)
+
 
     def _handle_system_status_event(self, event: SystemStatusEvent) -> None:
         """

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -2,7 +2,13 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, List
 
-from .event import BaseEvent, ZoneUpdate_1_16, ZoneUpdate_17_32, ArmingUpdate, SystemStatusEvent
+from .event import (
+    BaseEvent,
+    ZoneUpdate_1_16,
+    ZoneUpdate_17_32,
+    ArmingUpdate,
+    SystemStatusEvent,
+)
 
 
 class ArmingState(Enum):
@@ -64,8 +70,8 @@ class Alarm:
         ):
             self._handle_zone_1_16_input_update(event)
         elif (
-                isinstance(event, ZoneUpdate_17_32)
-                and event.request_id == ZoneUpdate_17_32.RequestID.ZONE_17_32_INPUT_UNSEALED
+            isinstance(event, ZoneUpdate_17_32)
+            and event.request_id == ZoneUpdate_17_32.RequestID.ZONE_17_32_INPUT_UNSEALED
         ):
             self._handle_zone_17_32_input_update(event)
         elif isinstance(event, SystemStatusEvent):
@@ -111,13 +117,12 @@ class Alarm:
 
     def _handle_zone_17_32_input_update(self, update: ZoneUpdate_17_32) -> None:
         for i, zone in enumerate(self.zones[16:]):
-            zone_id = i + 1
+            zone_id = i + 17
             name = "ZONE_{}".format(zone_id)
             if ZoneUpdate_17_32.Zone[name] in update.included_zones:
                 self._update_zone(zone_id, True)
             else:
                 self._update_zone(zone_id, False)
-
 
     def _handle_system_status_event(self, event: SystemStatusEvent) -> None:
         """

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, List
-
 from .event import (
     BaseEvent,
     ZoneUpdate_1_16,

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -67,7 +67,7 @@ class Alarm:
 
     @property
     def zones(self) -> List[Zone]:
-        if self.panel_model == PanelVersionUpdate.Model.D32X:
+        if self.panel_model is None or self.panel_model == PanelVersionUpdate.Model.D32X:
             return self._zones
 
         return self._zones[:16]

--- a/nessclient/cli/server/alarm_server.py
+++ b/nessclient/cli/server/alarm_server.py
@@ -13,7 +13,7 @@ from .zone import Zone
 from ...event import (
     SystemStatusEvent,
     ArmingUpdate,
-    ZoneUpdate,
+    ZoneUpdate_1_16,
     StatusUpdate,
     PanelVersionUpdate,
 )
@@ -369,8 +369,8 @@ class AlarmServer:
         self._server.write_event(event)
 
     def _handle_zone_input_unsealed_status_update_request(self) -> None:
-        event = ZoneUpdate(
-            request_id=StatusUpdate.RequestID.ZONE_INPUT_UNSEALED,
+        event = ZoneUpdate_1_16(
+            request_id=StatusUpdate.RequestID.ZONE_1_16_INPUT_UNSEALED,
             included_zones=[
                 get_zone_for_id(z.id)
                 for z in self._alarm.zones
@@ -513,6 +513,6 @@ def toggled_state(state: Zone.State) -> Zone.State:
         return Zone.State.SEALED
 
 
-def get_zone_for_id(zone_id: int) -> ZoneUpdate.Zone:
+def get_zone_for_id(zone_id: int) -> ZoneUpdate_1_16.Zone:
     key = "ZONE_{}".format(zone_id)
-    return ZoneUpdate.Zone[key]
+    return ZoneUpdate_1_16.Zone[key]

--- a/nessclient/cli/tui.py
+++ b/nessclient/cli/tui.py
@@ -80,8 +80,6 @@ async def interactive_ui(
     # Initial update and panel version request
     _add_log(logs, "TX", "Update")
     await client.update()
-    _add_log(logs, "TX", "S17 (Panel Version)")
-    await client.send_command("S17")
 
     stdscr = curses.initscr()
     curses.noecho()

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -5,7 +5,6 @@ from asyncio import sleep
 from typing import Callable, Dict
 
 from justbackoff import Backoff
-
 from .alarm import ArmingState, Alarm, ArmingMode
 from .connection import Connection, IP232Connection, Serial232Connection
 from .event import BaseEvent, DecodeOptions, StatusUpdate

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -5,6 +5,7 @@ from asyncio import sleep
 from typing import Callable, Dict
 
 from justbackoff import Backoff
+
 from .alarm import ArmingState, Alarm, ArmingMode
 from .connection import Connection, IP232Connection, Serial232Connection
 from .event import BaseEvent, DecodeOptions, StatusUpdate

--- a/nessclient/event.py
+++ b/nessclient/event.py
@@ -141,25 +141,42 @@ class SystemStatusEvent(BaseEvent):
 
 class StatusUpdate(BaseEvent):
     class RequestID(Enum):
-        ZONE_INPUT_UNSEALED = 0x0
-        ZONE_RADIO_UNSEALED = 0x1
-        ZONE_CBUS_UNSEALED = 0x2
-        ZONE_IN_DELAY = 0x3
-        ZONE_IN_DOUBLE_TRIGGER = 0x4
-        ZONE_IN_ALARM = 0x5
-        ZONE_EXCLUDED = 0x6
-        ZONE_AUTO_EXCLUDED = 0x7
-        ZONE_SUPERVISION_FAIL_PENDING = 0x8
-        ZONE_SUPERVISION_FAIL = 0x9
-        ZONE_DOORS_OPEN = 0x10
-        ZONE_DETECTOR_LOW_BATTERY = 0x11
-        ZONE_DETECTOR_TAMPER = 0x12
+        ZONE_1_16_INPUT_UNSEALED = 0x0
+        ZONE_1_16_RADIO_UNSEALED = 0x1
+        ZONE_1_16_CBUS_UNSEALED = 0x2
+        ZONE_1_16_IN_DELAY = 0x3
+        ZONE_1_16_IN_DOUBLE_TRIGGER = 0x4
+        ZONE_1_16_IN_ALARM = 0x5
+        ZONE_1_16_EXCLUDED = 0x6
+        ZONE_1_16_AUTO_EXCLUDED = 0x7
+        ZONE_1_16_SUPERVISION_FAIL_PENDING = 0x8
+        ZONE_1_16_SUPERVISION_FAIL = 0x9
+        ZONE_1_16_DOORS_OPEN = 0x10
+        ZONE_1_16_DETECTOR_LOW_BATTERY = 0x11
+        ZONE_1_16_DETECTOR_TAMPER = 0x12
         MISCELLANEOUS_ALARMS = 0x13
         ARMING = 0x14
         OUTPUTS = 0x15
         VIEW_STATE = 0x16
         PANEL_VERSION = 0x17
         AUXILIARY_OUTPUTS = 0x18
+        ZONE_1_16_EXCLUDED_PLUS_AUTO_EXCLUDED = 0x19
+        # DPLUS 32-zone panels introduce parallel request IDs for zones 17–32.
+        # Values follow the spec IDs directly as hex.
+        ZONE_17_32_INPUT_UNSEALED = 0x20
+        ZONE_17_32_RADIO_UNSEALED = 0x21
+        ZONE_17_32_CBUS_UNSEALED = 0x22
+        ZONE_17_32_IN_DELAY = 0x23
+        ZONE_17_32_IN_DOUBLE_TRIGGER = 0x24
+        ZONE_17_32_IN_ALARM = 0x25
+        ZONE_17_32_EXCLUDED = 0x26
+        ZONE_17_32_AUTO_EXCLUDED = 0x27
+        ZONE_17_32_SUPERVISION_FAIL_PENDING = 0x28
+        ZONE_17_32_SUPERVISION_FAIL = 0x29
+        ZONE_17_32_DOORS_OPEN = 0x30
+        ZONE_17_32_DETECTOR_LOW_BATTERY = 0x31
+        ZONE_17_32_DETECTOR_TAMPER = 0x32
+        ZONE_17_32_EXCLUDED_PLUS_AUTO_EXCLUDED = 0x33
 
     def __init__(
         self,
@@ -175,8 +192,10 @@ class StatusUpdate(BaseEvent):
         self, packet: Packet, options: DecodeOptions | None = None
     ) -> "StatusUpdate":
         request_id = StatusUpdate.RequestID(int(packet.data[0:2], 16))
-        if request_id.name.startswith("ZONE"):
-            return ZoneUpdate.decode(packet, options)
+        if request_id.name.startswith("ZONE_1_16"):
+            return ZoneUpdate_1_16.decode(packet, options)
+        elif request_id.name.startswith("ZONE_17_32"):
+            return ZoneUpdate_17_32.decode(packet, options)
         elif request_id == StatusUpdate.RequestID.MISCELLANEOUS_ALARMS:
             return MiscellaneousAlarmsUpdate.decode(packet, options)
         elif request_id == StatusUpdate.RequestID.ARMING:
@@ -193,7 +212,7 @@ class StatusUpdate(BaseEvent):
             raise ValueError("Unhandled request_id case: {}".format(request_id))
 
 
-class ZoneUpdate(StatusUpdate):
+class ZoneUpdate_1_16(StatusUpdate):
     class Zone(Enum):
         ZONE_1 = 0x0100
         ZONE_2 = 0x0200
@@ -214,22 +233,82 @@ class ZoneUpdate(StatusUpdate):
 
     def __init__(
         self,
-        included_zones: List["ZoneUpdate.Zone"],
+        included_zones: List["ZoneUpdate_1_16.Zone"],
         request_id: "StatusUpdate.RequestID",
         address: int | None,
         timestamp: datetime.datetime | None,
     ) -> None:
-        super(ZoneUpdate, self).__init__(
+        super(ZoneUpdate_1_16, self).__init__(
             request_id=request_id, address=address, timestamp=timestamp
         )
         self.included_zones = included_zones
 
     @classmethod
-    def decode(cls, packet: Packet, options: DecodeOptions | None = None) -> "ZoneUpdate":
+    def decode(
+        cls, packet: Packet, options: DecodeOptions | None = None
+    ) -> "ZoneUpdate_1_16":
         request_id = StatusUpdate.RequestID(int(packet.data[0:2], 16))
-        return ZoneUpdate(
+        return ZoneUpdate_1_16(
             request_id=request_id,
-            included_zones=unpack_unsigned_short_data_enum(packet, ZoneUpdate.Zone),
+            included_zones=unpack_unsigned_short_data_enum(packet, ZoneUpdate_1_16.Zone),
+            timestamp=packet.timestamp,
+            address=packet.address,
+        )
+
+    def encode(self) -> Packet:
+        data = "{:02x}{}".format(
+            self.request_id.value,
+            pack_unsigned_short_data_enum(self.included_zones),
+        )
+        return Packet(
+            address=self.address,
+            seq=0x00,
+            command=CommandType.USER_INTERFACE,
+            data=data,
+            timestamp=None,
+            is_user_interface_resp=True,
+        )
+
+
+class ZoneUpdate_17_32(StatusUpdate):
+    class Zone(Enum):
+        ZONE_17 = 0x0100
+        ZONE_18 = 0x0200
+        ZONE_19 = 0x0400
+        ZONE_20 = 0x0800
+        ZONE_21 = 0x1000
+        ZONE_22 = 0x2000
+        ZONE_23 = 0x4000
+        ZONE_24 = 0x8000
+        ZONE_25 = 0x0001
+        ZONE_26 = 0x0002
+        ZONE_27 = 0x0004
+        ZONE_28 = 0x0008
+        ZONE_29 = 0x0010
+        ZONE_30 = 0x0020
+        ZONE_31 = 0x0040
+        ZONE_32 = 0x0080
+
+    def __init__(
+        self,
+        included_zones: List["ZoneUpdate_17_32.Zone"],
+        request_id: "StatusUpdate.RequestID",
+        address: int | None,
+        timestamp: datetime.datetime | None,
+    ) -> None:
+        super(ZoneUpdate_17_32, self).__init__(
+            request_id=request_id, address=address, timestamp=timestamp
+        )
+        self.included_zones = included_zones
+
+    @classmethod
+    def decode(
+        cls, packet: Packet, options: DecodeOptions | None = None
+    ) -> "ZoneUpdate_17_32":
+        request_id = StatusUpdate.RequestID(int(packet.data[0:2], 16))
+        return ZoneUpdate_17_32(
+            request_id=request_id,
+            included_zones=unpack_unsigned_short_data_enum(packet, ZoneUpdate_17_32.Zone),
             timestamp=packet.timestamp,
             address=packet.address,
         )

--- a/nessclient_tests/test_alarm.py
+++ b/nessclient_tests/test_alarm.py
@@ -307,6 +307,68 @@ def test_handle_event_system_status_sealed_zone_calls_callback(alarm):
     assert cb.call_args[0] == (1, False)
 
 
+def test_handle_event_system_status_unsealed_zone_32(alarm):
+    alarm.zones[31].triggered = False
+
+    event = SystemStatusEvent(
+        address=None,
+        timestamp=None,
+        type=SystemStatusEvent.EventType.UNSEALED,
+        area=0,
+        zone=32,
+    )
+    alarm.handle_event(event)
+    assert alarm.zones[31].triggered is True
+
+
+def test_handle_event_system_status_unsealed_zone_32_calls_callback(alarm):
+    alarm.zones[31].triggered = False
+
+    cb = Mock()
+    alarm.on_zone_change(cb)
+    event = SystemStatusEvent(
+        address=None,
+        timestamp=None,
+        type=SystemStatusEvent.EventType.UNSEALED,
+        area=0,
+        zone=32,
+    )
+    alarm.handle_event(event)
+    assert cb.call_count == 1
+    assert cb.call_args[0] == (32, True)
+
+
+def test_handle_event_system_status_sealed_zone_32(alarm):
+    alarm.zones[31].triggered = True
+
+    event = SystemStatusEvent(
+        address=None,
+        timestamp=None,
+        type=SystemStatusEvent.EventType.SEALED,
+        area=0,
+        zone=32,
+    )
+    alarm.handle_event(event)
+    assert alarm.zones[31].triggered is False
+
+
+def test_handle_event_system_status_sealed_zone_32_calls_callback(alarm):
+    alarm.zones[31].triggered = True
+
+    cb = Mock()
+    alarm.on_zone_change(cb)
+    event = SystemStatusEvent(
+        address=None,
+        timestamp=None,
+        type=SystemStatusEvent.EventType.SEALED,
+        area=0,
+        zone=32,
+    )
+    alarm.handle_event(event)
+    assert cb.call_count == 1
+    assert cb.call_args[0] == (32, False)
+
+
 def test_handle_event_system_status_alarm(alarm):
     event = SystemStatusEvent(
         address=None,

--- a/nessclient_tests/test_alarm.py
+++ b/nessclient_tests/test_alarm.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from nessclient.alarm import Alarm, ArmingState, ArmingMode
-from nessclient.event import ArmingUpdate, ZoneUpdate, SystemStatusEvent
+from nessclient.event import ArmingUpdate, ZoneUpdate_1_16, SystemStatusEvent
 
 
 def test_state_is_initially_unknown(alarm):
@@ -15,16 +15,16 @@ def test_zones_are_initially_unknown(alarm):
         assert zone.triggered is None
 
 
-def test_16_zones_are_created(alarm):
-    assert len(alarm.zones) == 16
+def test_32_zones_are_created(alarm):
+    assert len(alarm.zones) == 32
 
 
 def test_handle_event_zone_update(alarm):
-    event = ZoneUpdate(
-        included_zones=[ZoneUpdate.Zone.ZONE_1, ZoneUpdate.Zone.ZONE_3],
+    event = ZoneUpdate_1_16(
+        included_zones=[ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
         timestamp=None,
         address=None,
-        request_id=ZoneUpdate.RequestID.ZONE_INPUT_UNSEALED,
+        request_id=ZoneUpdate_1_16.RequestID.ZONE_1_16_INPUT_UNSEALED,
     )
     alarm.handle_event(event)
     assert alarm.zones[0].triggered is True
@@ -36,11 +36,11 @@ def test_handle_event_zone_update_sealed(alarm):
     alarm.zones[0].triggered = True
     alarm.zones[1].triggered = True
 
-    event = ZoneUpdate(
-        included_zones=[ZoneUpdate.Zone.ZONE_1, ZoneUpdate.Zone.ZONE_3],
+    event = ZoneUpdate_1_16(
+        included_zones=[ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
         timestamp=None,
         address=None,
-        request_id=ZoneUpdate.RequestID.ZONE_INPUT_UNSEALED,
+        request_id=ZoneUpdate_1_16.RequestID.ZONE_1_16_INPUT_UNSEALED,
     )
     alarm.handle_event(event)
     assert alarm.zones[0].triggered is True
@@ -55,11 +55,11 @@ def test_handle_event_zone_update_callback(alarm):
 
     cb = Mock()
     alarm.on_zone_change(cb)
-    event = ZoneUpdate(
-        included_zones=[ZoneUpdate.Zone.ZONE_1, ZoneUpdate.Zone.ZONE_3],
+    event = ZoneUpdate_1_16(
+        included_zones=[ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
         timestamp=None,
         address=None,
-        request_id=ZoneUpdate.RequestID.ZONE_INPUT_UNSEALED,
+        request_id=ZoneUpdate_1_16.RequestID.ZONE_1_16_INPUT_UNSEALED,
     )
     alarm.handle_event(event)
     assert cb.call_count == 3

--- a/nessclient_tests/test_alarm.py
+++ b/nessclient_tests/test_alarm.py
@@ -75,7 +75,7 @@ def test_handle_event_zone_update_1_16_callback(alarm):
 
 def test_handle_event_zone_update_1_16_does_not_affect_17_32(alarm):
     # Seed some 17–32 states
-    alarm.zones[16].triggered = True   # zone 17
+    alarm.zones[16].triggered = True  # zone 17
     alarm.zones[20].triggered = False  # zone 21
 
     # Apply a 1–16 update
@@ -154,7 +154,7 @@ def test_handle_event_zone_update_17_32_callback(alarm):
 
 def test_handle_event_zone_update_17_32_does_not_affect_1_16(alarm):
     # Seed some 1–16 states
-    alarm.zones[0].triggered = True   # zone 1
+    alarm.zones[0].triggered = True  # zone 1
     alarm.zones[5].triggered = False  # zone 6
 
     # Apply a 17–32 update

--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -266,7 +266,7 @@ class SystemStatusEventTestCase(unittest.TestCase):
         self.assertEqual(event.zone, 0)
         self.assertEqual(event.type, SystemStatusEvent.EventType.EXIT_DELAY_END)
 
-    def test_zone_sealed(self):
+    def test_zone_sealed_with_zone_5(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "010500")
         event = SystemStatusEvent.decode(pkt)
         self.assertEqual(event.area, 0)
@@ -285,6 +285,48 @@ class SystemStatusEventTestCase(unittest.TestCase):
         event = SystemStatusEvent.decode(pkt)
         self.assertEqual(event.area, 0)
         self.assertEqual(event.zone, 16)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
+
+    def test_zone_sealed_with_zone_17_in_area_1(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "011701")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 17)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.SEALED)
+
+    def test_zone_unsealed_with_zone_17_in_area_1(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "001701")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 17)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
+
+    def test_zone_sealed_with_zone_17(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "011700")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 17)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.SEALED)
+
+    def test_zone_unsealed_with_zone_17(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "001700")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 17)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
+
+    def test_zone_sealed_with_zone_32(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "013200")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 32)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.SEALED)
+
+    def test_zone_unsealed_with_zone_32(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "003200")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 32)
         self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
 
 

--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -338,6 +338,41 @@ class SystemStatusEventTestCase(unittest.TestCase):
         self.assertEqual(event.zone, 32)
         self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
 
+    def test_zone_alarm_with_zone_5_area_1(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "020501")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.ALARM)
+
+    def test_tamper_unsealed_with_zone_5_radio(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "080591")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0x91)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.TAMPER_UNSEALED)
+
+    def test_power_failure(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "100000")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 0)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.POWER_FAILURE)
+
+    def test_entry_delay_start(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "200501")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.ENTRY_DELAY_START)
+
+    def test_output_on(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "310100")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 1)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.OUTPUT_ON)
+
 
 Rev16DecodeOptions = DecodeOptions(
     panel_version_update_model_mapper=PanelVersionUpdate.ModelRev16Mapper

--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -175,6 +175,29 @@ class ZoneUpdate1To16TestCase(unittest.TestCase):
             [ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
         )
 
+    def test_zone_1_16_additional_requests_with_zones(self):
+        cases = [
+            ("000500", ZoneUpdate_1_16.RequestID.ZONE_1_16_INPUT_UNSEALED),
+            ("020500", ZoneUpdate_1_16.RequestID.ZONE_1_16_CBUS_UNSEALED),
+            ("040500", ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_DOUBLE_TRIGGER),
+            ("060500", ZoneUpdate_1_16.RequestID.ZONE_1_16_EXCLUDED),
+            ("070500", ZoneUpdate_1_16.RequestID.ZONE_1_16_AUTO_EXCLUDED),
+            ("080500", ZoneUpdate_1_16.RequestID.ZONE_1_16_SUPERVISION_FAIL_PENDING),
+            ("090500", ZoneUpdate_1_16.RequestID.ZONE_1_16_SUPERVISION_FAIL),
+            ("100500", ZoneUpdate_1_16.RequestID.ZONE_1_16_DOORS_OPEN),
+            ("110500", ZoneUpdate_1_16.RequestID.ZONE_1_16_DETECTOR_LOW_BATTERY),
+            ("120500", ZoneUpdate_1_16.RequestID.ZONE_1_16_DETECTOR_TAMPER),
+        ]
+        for data, request in cases:
+            with self.subTest(request=request):
+                pkt = make_packet(CommandType.USER_INTERFACE, data)
+                event = ZoneUpdate_1_16.decode(pkt)
+                self.assertEqual(event.request_id, request)
+                self.assertEqual(
+                    event.included_zones,
+                    [ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
+                )
+
 
 class ZoneUpdate17To32TestCase(unittest.TestCase):
     def test_encode(self):
@@ -239,6 +262,35 @@ class ZoneUpdate17To32TestCase(unittest.TestCase):
             event.included_zones,
             [ZoneUpdate_17_32.Zone.ZONE_17, ZoneUpdate_17_32.Zone.ZONE_19],
         )
+
+    def test_zone_17_32_additional_requests_with_zones(self):
+        cases = [
+            ("200500", ZoneUpdate_17_32.RequestID.ZONE_17_32_INPUT_UNSEALED),
+            ("220500", ZoneUpdate_17_32.RequestID.ZONE_17_32_CBUS_UNSEALED),
+            ("240500", ZoneUpdate_17_32.RequestID.ZONE_17_32_IN_DOUBLE_TRIGGER),
+            ("260500", ZoneUpdate_17_32.RequestID.ZONE_17_32_EXCLUDED),
+            ("270500", ZoneUpdate_17_32.RequestID.ZONE_17_32_AUTO_EXCLUDED),
+            (
+                "280500",
+                ZoneUpdate_17_32.RequestID.ZONE_17_32_SUPERVISION_FAIL_PENDING,
+            ),
+            ("290500", ZoneUpdate_17_32.RequestID.ZONE_17_32_SUPERVISION_FAIL),
+            ("300500", ZoneUpdate_17_32.RequestID.ZONE_17_32_DOORS_OPEN),
+            (
+                "310500",
+                ZoneUpdate_17_32.RequestID.ZONE_17_32_DETECTOR_LOW_BATTERY,
+            ),
+            ("320500", ZoneUpdate_17_32.RequestID.ZONE_17_32_DETECTOR_TAMPER),
+        ]
+        for data, request in cases:
+            with self.subTest(request=request):
+                pkt = make_packet(CommandType.USER_INTERFACE, data)
+                event = ZoneUpdate_17_32.decode(pkt)
+                self.assertEqual(event.request_id, request)
+                self.assertEqual(
+                    event.included_zones,
+                    [ZoneUpdate_17_32.Zone.ZONE_17, ZoneUpdate_17_32.Zone.ZONE_19],
+                )
 
 
 class ViewStateUpdateTestCase(unittest.TestCase):

--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -151,6 +151,18 @@ class ZoneUpdate1To16TestCase(unittest.TestCase):
             [ZoneUpdate_1_16.Zone.ZONE_3, ZoneUpdate_1_16.Zone.ZONE_5],
         )
 
+    def test_zone_radio_unsealed_with_zones(self):
+        pkt = make_packet(CommandType.USER_INTERFACE, "010500")
+        event = ZoneUpdate_1_16.decode(pkt)
+        self.assertEqual(
+            event.request_id,
+            ZoneUpdate_1_16.RequestID.ZONE_1_16_RADIO_UNSEALED,
+        )
+        self.assertEqual(
+            event.included_zones,
+            [ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
+        )
+
     def test_zone_1_16_excluded_plus_auto(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "190500")
         event = ZoneUpdate_1_16.decode(pkt)
@@ -199,6 +211,18 @@ class ZoneUpdate17To32TestCase(unittest.TestCase):
         pkt = make_packet(CommandType.USER_INTERFACE, "250500")
         event = ZoneUpdate_17_32.decode(pkt)
         self.assertEqual(event.request_id, ZoneUpdate_17_32.RequestID.ZONE_17_32_IN_ALARM)
+        self.assertEqual(
+            event.included_zones,
+            [ZoneUpdate_17_32.Zone.ZONE_17, ZoneUpdate_17_32.Zone.ZONE_19],
+        )
+
+    def test_zone_radio_unsealed_with_zones(self):
+        pkt = make_packet(CommandType.USER_INTERFACE, "210500")
+        event = ZoneUpdate_17_32.decode(pkt)
+        self.assertEqual(
+            event.request_id,
+            ZoneUpdate_17_32.RequestID.ZONE_17_32_RADIO_UNSEALED,
+        )
         self.assertEqual(
             event.included_zones,
             [ZoneUpdate_17_32.Zone.ZONE_17, ZoneUpdate_17_32.Zone.ZONE_19],
@@ -484,6 +508,69 @@ class SystemStatusEventTestCase(unittest.TestCase):
         self.assertEqual(event.area, 0)
         self.assertEqual(event.zone, 1)
         self.assertEqual(event.type, SystemStatusEvent.EventType.OUTPUT_OFF)
+
+    def test_manual_exclude_with_zone_5_area_1(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "040501")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.MANUAL_EXCLUDE)
+
+    def test_manual_include_with_zone_5_area_1(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "050501")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.MANUAL_INCLUDE)
+
+    def test_auto_exclude_with_zone_5_area_1(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "060501")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.AUTO_EXCLUDE)
+
+    def test_auto_include_with_zone_5_area_1(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "070501")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.AUTO_INCLUDE)
+
+    def test_armed_home(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "250103")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 3)
+        self.assertEqual(event.zone, 1)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMED_HOME)
+
+    def test_armed_day(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "260004")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 4)
+        self.assertEqual(event.zone, 0)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMED_DAY)
+
+    def test_armed_night(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "270000")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 0)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMED_NIGHT)
+
+    def test_armed_vacation(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "280000")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 0)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMED_VACATION)
+
+    def test_armed_highest(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "2e0000")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 0)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMED_HIGHEST)
 
 
 Rev16DecodeOptions = DecodeOptions(

--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -373,6 +373,118 @@ class SystemStatusEventTestCase(unittest.TestCase):
         self.assertEqual(event.zone, 1)
         self.assertEqual(event.type, SystemStatusEvent.EventType.OUTPUT_ON)
 
+    def test_alarm_restore_with_zone_5_area_1(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "030501")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.ALARM_RESTORE)
+
+    def test_tamper_normal_with_zone_5_radio(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "090591")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0x91)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.TAMPER_NORMAL)
+
+    def test_power_normal(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "110000")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 0)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.POWER_NORMAL)
+
+    def test_battery_failure(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "120000")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 0)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.BATTERY_FAILURE)
+
+    def test_battery_normal(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "130000")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 0)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.BATTERY_NORMAL)
+
+    def test_report_failure(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "140000")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 0)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.REPORT_FAILURE)
+
+    def test_report_normal(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "150000")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 0)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.REPORT_NORMAL)
+
+    def test_supervision_failure_zone_5(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "160500")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.SUPERVISION_FAILURE)
+
+    def test_supervision_normal_zone_5(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "170500")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.SUPERVISION_NORMAL)
+
+    def test_real_time_clock(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "190000")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 0)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.REAL_TIME_CLOCK)
+
+    def test_entry_delay_end(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "210501")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.ENTRY_DELAY_END)
+
+    def test_exit_delay_start(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "220501")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 5)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.EXIT_DELAY_START)
+
+    def test_armed_away(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "240101")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 1)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMED_AWAY)
+
+    def test_disarmed(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "2f0101")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 1)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.DISARMED)
+
+    def test_arming_delayed(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "300101")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 1)
+        self.assertEqual(event.zone, 1)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMING_DELAYED)
+
+    def test_output_off(self):
+        pkt = make_packet(CommandType.SYSTEM_STATUS, "320100")
+        event = SystemStatusEvent.decode(pkt)
+        self.assertEqual(event.area, 0)
+        self.assertEqual(event.zone, 1)
+        self.assertEqual(event.type, SystemStatusEvent.EventType.OUTPUT_OFF)
+
 
 Rev16DecodeOptions = DecodeOptions(
     panel_version_update_model_mapper=PanelVersionUpdate.ModelRev16Mapper

--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -195,6 +195,15 @@ class ZoneUpdate17To32TestCase(unittest.TestCase):
             [ZoneUpdate_17_32.Zone.ZONE_17, ZoneUpdate_17_32.Zone.ZONE_19],
         )
 
+    def test_zone_in_alarm_with_zones(self):
+        pkt = make_packet(CommandType.USER_INTERFACE, "250500")
+        event = ZoneUpdate_17_32.decode(pkt)
+        self.assertEqual(event.request_id, ZoneUpdate_17_32.RequestID.ZONE_17_32_IN_ALARM)
+        self.assertEqual(
+            event.included_zones,
+            [ZoneUpdate_17_32.Zone.ZONE_17, ZoneUpdate_17_32.Zone.ZONE_19],
+        )
+
     def test_zone_excluded_plus_auto(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "330500")
         event = ZoneUpdate_17_32.decode(pkt)

--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -2,7 +2,7 @@ import unittest
 from typing import cast
 
 from nessclient.event import (
-    ZoneUpdate,
+    ZoneUpdate_1_16,
     pack_unsigned_short_data_enum,
     ArmingUpdate,
     StatusUpdate,
@@ -20,7 +20,7 @@ from nessclient.packet import Packet, CommandType
 
 class UtilsTestCase(unittest.TestCase):
     def test_pack_unsigned_short_data_enum(self):
-        value = [ZoneUpdate.Zone.ZONE_1, ZoneUpdate.Zone.ZONE_4]
+        value = [ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_4]
         self.assertEqual(
             "0900",
             pack_unsigned_short_data_enum(value),
@@ -47,7 +47,7 @@ class StatusUpdateTestCase(unittest.TestCase):
     def test_decode_zone_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "000000")
         event = StatusUpdate.decode(pkt)
-        self.assertTrue(isinstance(event, ZoneUpdate))
+        self.assertTrue(isinstance(event, ZoneUpdate_1_16))
 
     def test_decode_misc_alarms_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "130000")
@@ -110,9 +110,9 @@ class ArmingUpdateTestCase(unittest.TestCase):
 
 class ZoneUpdateTestCase(unittest.TestCase):
     def test_encode(self):
-        event = ZoneUpdate(
-            included_zones=[ZoneUpdate.Zone.ZONE_1, ZoneUpdate.Zone.ZONE_3],
-            request_id=StatusUpdate.RequestID.ZONE_INPUT_UNSEALED,
+        event = ZoneUpdate_1_16(
+            included_zones=[ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
+            request_id=StatusUpdate.RequestID.ZONE_1_16_INPUT_UNSEALED,
             timestamp=None,
             address=0x00,
         )
@@ -123,24 +123,26 @@ class ZoneUpdateTestCase(unittest.TestCase):
 
     def test_zone_in_delay_no_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "030000")
-        event = ZoneUpdate.decode(pkt)
-        self.assertEqual(event.request_id, ZoneUpdate.RequestID.ZONE_IN_DELAY)
+        event = ZoneUpdate_1_16.decode(pkt)
+        self.assertEqual(event.request_id, ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_DELAY)
         self.assertEqual(event.included_zones, [])
 
     def test_zone_in_delay_with_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "030500")
-        event = ZoneUpdate.decode(pkt)
-        self.assertEqual(event.request_id, ZoneUpdate.RequestID.ZONE_IN_DELAY)
+        event = ZoneUpdate_1_16.decode(pkt)
+        self.assertEqual(event.request_id, ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_DELAY)
         self.assertEqual(
-            event.included_zones, [ZoneUpdate.Zone.ZONE_1, ZoneUpdate.Zone.ZONE_3]
+            event.included_zones,
+            [ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
         )
 
     def test_zone_in_alarm_with_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "051400")
-        event = ZoneUpdate.decode(pkt)
-        self.assertEqual(event.request_id, ZoneUpdate.RequestID.ZONE_IN_ALARM)
+        event = ZoneUpdate_1_16.decode(pkt)
+        self.assertEqual(event.request_id, ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_ALARM)
         self.assertEqual(
-            event.included_zones, [ZoneUpdate.Zone.ZONE_3, ZoneUpdate.Zone.ZONE_5]
+            event.included_zones,
+            [ZoneUpdate_1_16.Zone.ZONE_3, ZoneUpdate_1_16.Zone.ZONE_5],
         )
 
 

--- a/nessclient_tests/test_packet.py
+++ b/nessclient_tests/test_packet.py
@@ -158,3 +158,41 @@ class PacketTestCase(unittest.TestCase):
         event = BaseEvent.decode(pkt)
         print(pkt)
         print(event)
+
+    def test_decode_status_update_response_zone_17_32_none(self):
+        # Zone 17-32 Input Unsealed (ID 0x20), no zones set
+        pkt = Packet.decode("82000360200000ff")
+        self.assertEqual(pkt.start, 0x82)
+        self.assertEqual(pkt.address, 0x00)
+        self.assertEqual(pkt.length, 3)
+        self.assertEqual(pkt.seq, 0x00)
+        self.assertEqual(pkt.command, CommandType.USER_INTERFACE)
+        self.assertEqual(pkt.data, "200000")
+        self.assertIsNone(pkt.timestamp)
+        self.assertTrue(pkt.is_user_interface_resp)
+
+    def test_decode_status_update_response_zone_17_32_in_alarm_zone17(self):
+        # Zone 17-32 In Alarm (ID 0x25), Zone 17 set
+        pkt = Packet.decode("82000360250100aa")
+        self.assertEqual(pkt.data, "250100")
+        self.assertTrue(pkt.is_user_interface_resp)
+
+    def test_decode_status_update_response_zone_23_unsealed_example(self):
+        # From FORM 5 examples in the spec (address 0x07)
+        # Example: Zone 23 unseal (ID 0x20, data 0x4000)
+        pkt = Packet.decode("8207036020400013")
+        self.assertEqual(pkt.start, 0x82)
+        self.assertEqual(pkt.address, 0x07)
+        self.assertEqual(pkt.length, 3)
+        self.assertEqual(pkt.seq, 0x00)
+        self.assertEqual(pkt.command, CommandType.USER_INTERFACE)
+        self.assertEqual(pkt.data, "204000")
+        self.assertTrue(pkt.is_user_interface_resp)
+
+    def test_decode_status_update_response_zone_23_24_unsealed_example(self):
+        # From FORM 5 examples in the spec (address 0x07)
+        # Example: Zones 23 and 24 unseal (ID 0x20, data 0xC000)
+        pkt = Packet.decode("8207036020c00054")
+        self.assertEqual(pkt.address, 0x07)
+        self.assertEqual(pkt.data, "20c000")
+        self.assertTrue(pkt.is_user_interface_resp)


### PR DESCRIPTION
## Summary
- test alarm handles system status events for zone 32
- test decoding 32-zone alarm updates

## Testing
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ada0f522048331a22124e0e084b730