### PR TITLE
Start fake alarm server with simulation disabled

### DIFF
--- a/nessclient/cli/server/alarm_server.py
+++ b/nessclient/cli/server/alarm_server.py
@@ -54,7 +54,6 @@ class AlarmServer:
 
     def start(self) -> None:
         self._server.start(host=self._host, port=self._port)
-        self._start_simulation()
         curses.wrapper(self._run_ui)
 
     def _run_ui(self, stdscr: Any) -> None:


### PR DESCRIPTION
## Summary
- keep the fake alarm server's simulation off on startup
- drop regression test per review feedback

## Testing
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ada1d2c06083318146d34bfd87ce87