### PR TITLE
Add Client.get_panel_info and tests

### DIFF
--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -2,7 +2,13 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Callable, List
 
-from .event import BaseEvent, ZoneUpdate, ArmingUpdate, SystemStatusEvent
+from .event import (
+    BaseEvent,
+    ZoneUpdate,
+    ArmingUpdate,
+    SystemStatusEvent,
+    PanelVersionUpdate,
+)
 
 
 class ArmingState(Enum):
@@ -22,6 +28,12 @@ class ArmingMode(Enum):
     ARMED_NIGHT = "ARMED_NIGHT"
     ARMED_VACATION = "ARMED_VACATION"
     ARMED_HIGHEST = "ARMED_HIGHEST"
+
+
+@dataclass
+class PanelInfo:
+    model: PanelVersionUpdate.Model
+    version: str
 
 
 class Alarm:

--- a/nessclient/alarm.py
+++ b/nessclient/alarm.py
@@ -59,6 +59,7 @@ class Alarm:
         self._infer_arming_state = infer_arming_state
         self.arming_state: ArmingState = ArmingState.UNKNOWN
         self.zones: List[Alarm.Zone] = [Alarm.Zone(triggered=None) for _ in range(16)]
+        self.panel_info: PanelInfo | None = None
 
         self._arming_mode: ArmingMode | None = None
 
@@ -77,6 +78,8 @@ class Alarm:
             self._handle_zone_input_update(event)
         elif isinstance(event, SystemStatusEvent):
             self._handle_system_status_event(event)
+        elif isinstance(event, PanelVersionUpdate):
+            self.panel_info = PanelInfo(model=event.model, version=event.version)
 
     def _handle_arming_update(self, update: ArmingUpdate) -> None:
         if update.status == [ArmingUpdate.ArmingStatus.AREA_1_ARMED]:

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -2,7 +2,7 @@ import asyncio
 import datetime
 import logging
 from asyncio import sleep
-from typing import Callable, Dict, cast
+from typing import Callable, Dict
 
 from justbackoff import Backoff
 
@@ -88,9 +88,8 @@ class Client:
         - Otherwise, sends `S17` and returns the parsed PanelVersionUpdate
           as a `PanelInfo` tuple.
         """
-        cached = getattr(self.alarm, "panel_info", None)
-        if cached is not None:
-            return cast(PanelInfo, cached)
+        if self.alarm.panel_info is not None:
+            return self.alarm.panel_info
 
         resp = await self.send_command_and_wait("S17")
         if isinstance(resp, PanelVersionUpdate):

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -82,19 +82,18 @@ class Client:
         return await self.send_command(command)
 
     async def get_panel_info(self) -> PanelInfo:
-        """Fetch and return panel information (model and version).
-
-        - Returns cached info if already known by the Alarm instance.
-        - Otherwise, sends `S17` and returns the parsed PanelVersionUpdate
-          as a `PanelInfo` tuple.
-        """
+        """Fetch and return panel information (model and version)."""
+        # Return panel info if we already know it.
         if self.alarm.panel_info is not None:
             return self.alarm.panel_info
 
         resp = await self.send_command_and_wait("S17")
         if isinstance(resp, PanelVersionUpdate):
-            # Alarm will also receive and may cache this via handle_event.
+            # The event dispatcher will also dispatch the event to the alarm
+            # entity which will handle the PanelVersionUpdate internally to set
+            # the panel_info property.
             return PanelInfo(model=resp.model, version=resp.version)
+
         raise RuntimeError(f"Unexpected response to S17: {resp}")
 
     async def update(self) -> None:

--- a/nessclient/event.py
+++ b/nessclient/event.py
@@ -469,7 +469,6 @@ class PanelVersionUpdate(StatusUpdate):
         # DPlus panel variants
         DPLUS8 = "DPLUS8"
 
-
     """Panel model and modem combinations prior to documentation revision 16.
 
     Previous documentation revisions did not specify explicit examples beyond:

--- a/nessclient_tests/test_client.py
+++ b/nessclient_tests/test_client.py
@@ -87,9 +87,7 @@ async def test_get_panel_info_cached_returns_without_io(
     connection, client: Client, alarm: Alarm
 ):
     # If panel_info is already known, get_panel_info returns it and performs no I/O
-    alarm.panel_info = PanelInfo(  # type: ignore[attr-defined]
-        model=PanelVersionUpdate.Model.D16X, version="8.7"
-    )
+    alarm.panel_info = PanelInfo(model=PanelVersionUpdate.Model.D16X, version="8.7")
 
     info = await client.get_panel_info()
     assert info.model == PanelVersionUpdate.Model.D16X
@@ -103,7 +101,7 @@ async def test_get_panel_info_probes_when_missing(
     connection, client: Client, alarm: Alarm
 ):
     # With no cached info, get_panel_info should send S17 and return parsed info
-    alarm.panel_info = None  # type: ignore[attr-defined]
+    alarm.panel_info = None
 
     # Patch send_command_and_wait to send S17 then return a PanelVersionUpdate
     orig_send_command = client.send_command

--- a/nessclient_tests/test_client.py
+++ b/nessclient_tests/test_client.py
@@ -3,9 +3,9 @@ from unittest.mock import Mock, AsyncMock
 import pytest
 
 from nessclient import Client
-from nessclient.alarm import Alarm
+from nessclient.alarm import Alarm, PanelInfo
 from nessclient.connection import Connection
-from nessclient.event import StatusUpdate, BaseEvent
+from nessclient.event import StatusUpdate, BaseEvent, PanelVersionUpdate
 from nessclient.packet import Packet, CommandType
 import asyncio
 
@@ -65,6 +65,63 @@ async def test_update(connection, client):
         get_data(connection.write.call_args_list[1][0][0]),
     }
     assert commands == {b"S00", b"S14"}
+
+
+def panel_version_response(
+    model: PanelVersionUpdate.Model,
+    major: int = 8,
+    minor: int = 7,
+) -> PanelVersionUpdate:
+    """Construct a PanelVersionUpdate event for PANEL_VERSION (S17)."""
+    return PanelVersionUpdate(
+        model=model,
+        major_version=major,
+        minor_version=minor,
+        address=0x00,
+        timestamp=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_panel_info_cached_returns_without_io(
+    connection, client: Client, alarm: Alarm
+):
+    # If panel_info is already known, get_panel_info returns it and performs no I/O
+    alarm.panel_info = PanelInfo(  # type: ignore[attr-defined]
+        model=PanelVersionUpdate.Model.D16X, version="8.7"
+    )
+
+    info = await client.get_panel_info()
+    assert info.model == PanelVersionUpdate.Model.D16X
+    assert info.version == "8.7"
+    # No writes should have occurred
+    assert connection.write.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_get_panel_info_probes_when_missing(
+    connection, client: Client, alarm: Alarm
+):
+    # With no cached info, get_panel_info should send S17 and return parsed info
+    alarm.panel_info = None  # type: ignore[attr-defined]
+
+    # Patch send_command_and_wait to send S17 then return a PanelVersionUpdate
+    orig_send_command = client.send_command
+
+    async def fake_scaw(command: str, timeout: float | None = 5.0):
+        await orig_send_command(command)
+        return panel_version_response(PanelVersionUpdate.Model.D32X, 8, 7)
+
+    client.send_command_and_wait = fake_scaw  # type: ignore[assignment]
+
+    info = await client.get_panel_info()
+    # Ensure S17 was sent
+    assert connection.write.call_count == 1
+    first = get_data(connection.write.call_args_list[0][0][0])
+    assert first == b"S17"
+    # Info returned should match the fake response
+    assert info.model == PanelVersionUpdate.Model.D32X
+    assert info.version == "8.7"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary
- Adds `Client.get_panel_info()` to query panel model and firmware version using the `S17` PANEL_VERSION request.
- Introduces a small `PanelInfo` dataclass in `nessclient.alarm` for type clarity and to carry `(model, version)`.
- Adds focused tests for both cached and probed flows.
- No changes to update/zone behavior or CLI—intentionally isolated for ease of review.

Details
- `get_panel_info()` returns cached `alarm.panel_info` when present; otherwise it sends `S17` and returns a `PanelInfo` constructed from the `PanelVersionUpdate` response.
- The `Alarm` continues to populate `panel_info` when a `PanelVersionUpdate` event is observed, but the helper is useful when the caller wants to fetch it on-demand.
- API is additive and non‑breaking; no constructor or behavior changes.

Protocol
- Uses `S17` (PANEL_VERSION) per the device protocol.

Testing
- New tests in `nessclient_tests/test_client.py`:
  - `test_get_panel_info_cached_returns_without_io`
  - `test_get_panel_info_probes_when_missing`
- Verified locally with `uv`:
  - `ruff format` and `ruff check` pass
  - `mypy --strict nessclient` passes
  - `pytest` passes

Notes / Follow‑ups
- Optionally surface the panel info in CLI/TUI (e.g., an explicit command or initial display) in a subsequent PR.
- Optionally add a short docs note in README about `get_panel_info()` usage.

Changelog
- feat(client): add `get_panel_info()` and `PanelInfo` dataclass; add tests.
