### PR TITLE
Remove non-interactive CLI modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ ness-cli --help
 
 The CLI exposes several high level commands:
 
-- `events` – listen for alarm events emitted by a connected panel. Use `--interactive` for a terminal UI with live zone status and event logs.
+- `events` – listen for alarm events emitted by a connected panel in a terminal UI with live zone status and event logs.
 - `send` – send a raw command to the panel.
 - `server` – run a dummy panel server, useful for local development when an alarm panel isn't available.
 - `version` – print the installed package version.
@@ -72,8 +72,7 @@ records each transmitted (`TX`) and received (`RX`) packet:
 ness-cli events --logfile packets.log
 ```
 
-This works in both normal and `--interactive` modes. Include the generated log
-file with bug reports to assist with troubleshooting.
+Include the generated log file with bug reports to assist with troubleshooting.
 
 ## API Documentation
 You can find the full API documentation [here](https://nessclient.readthedocs.io/en/latest/api.html)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,13 +11,12 @@ ness-cli --help
 
 ## Events command
 
-`ness-cli events` listens for events emitted by a connected alarm panel.
+`ness-cli events` listens for events emitted by a connected alarm panel and
+displays a terminal UI with live zone status and event logs.
 
 ```sh
 ness-cli events --host PANEL_HOST --port PORT
 ```
-
-Pass `--interactive` to launch a terminal UI with live zone status and event logs.
 
 ### Logging raw packets
 
@@ -27,12 +26,6 @@ command to record all transmitted (`TX`) and received (`RX`) packets:
 
 ```sh
 ness-cli events --logfile packets.log
-```
-
-The option also works with the interactive UI:
-
-```sh
-ness-cli events --interactive --logfile packets.log
 ```
 
 Include the generated file when raising an issue to help diagnose problems.

--- a/nessclient/cli/events.py
+++ b/nessclient/cli/events.py
@@ -1,13 +1,7 @@
 import asyncio
-from typing import TextIO
 
 import click
 
-from ..alarm import ArmingMode, ArmingState
-from ..client import Client
-from ..connection import IP232Connection, Serial232Connection
-from ..event import BaseEvent
-from .logging_connection import LoggingConnection
 from .server import DEFAULT_PORT
 
 
@@ -17,7 +11,6 @@ from .server import DEFAULT_PORT
 @click.option("--serial-tty")
 @click.option("--update-interval", type=int, default=60)
 @click.option("--infer-arming-state/--no-infer-arming-state")
-@click.option("--interactive", is_flag=True, help="Run with terminal UI")
 @click.option("--logfile", type=click.Path(), help="Write raw TX/RX packets to file")
 def events(
     host: str,
@@ -25,66 +18,17 @@ def events(
     update_interval: int,
     infer_arming_state: bool,
     serial_tty: str | None,
-    interactive: bool,
     logfile: str | None,
 ) -> None:
-    if interactive:
-        from .tui import interactive_ui
+    from .tui import interactive_ui
 
-        asyncio.run(
-            interactive_ui(
-                host=host,
-                port=port,
-                update_interval=update_interval,
-                infer_arming_state=infer_arming_state,
-                serial_tty=serial_tty,
-                packet_logfile=logfile,
-            )
+    asyncio.run(
+        interactive_ui(
+            host=host,
+            port=port,
+            update_interval=update_interval,
+            infer_arming_state=infer_arming_state,
+            serial_tty=serial_tty,
+            packet_logfile=logfile,
         )
-        return
-
-    log_fp: TextIO | None = open(logfile, "a") if logfile else None
-    connection = None
-    if log_fp is not None:
-        base_conn = (
-            IP232Connection(host=host, port=port)
-            if serial_tty is None
-            else Serial232Connection(tty_path=serial_tty)
-        )
-        connection = LoggingConnection(base_conn, log_fp)
-
-    loop = asyncio.get_event_loop()
-    client = Client(
-        connection=connection,
-        host=host if connection is None and serial_tty is None else None,
-        port=port if connection is None and serial_tty is None else None,
-        serial_tty=serial_tty if connection is None else None,
-        infer_arming_state=infer_arming_state,
-        update_interval=update_interval,
     )
-
-    @client.on_zone_change
-    def on_zone_change(zone: int, triggered: bool) -> None:
-        print(f"Zone {zone} changed to {triggered}")
-
-    @client.on_state_change
-    def on_state_change(state: ArmingState, arming_mode: ArmingMode | None) -> None:
-        print(f"Alarm state changed to {state} (mode: {arming_mode})")
-
-    @client.on_event_received
-    def on_event_received(event: BaseEvent) -> None:
-        print(event)
-
-    async def _init_panel_info() -> None:
-        try:
-            info = await client.get_panel_info()
-            print(f"Panel: {info.model.name} {info.version}")
-        except Exception as e:
-            # Non-fatal; continue receiving events
-            print(f"Failed to probe panel info: {e}")
-
-    loop.create_task(client.keepalive())
-    loop.create_task(client.update())
-    loop.create_task(_init_panel_info())
-
-    loop.run_forever()


### PR DESCRIPTION
## Summary
- Simplify `events` command to always launch interactive UI
- Update documentation to reflect that events are now interactive-only

## Testing
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aef318dfa08331b531496afdbc9dee