### PR TITLE
Add output support to fake server and events client

### DIFF
--- a/nessclient/cli/events.py
+++ b/nessclient/cli/events.py
@@ -67,6 +67,10 @@ def events(
     def on_zone_change(zone: int, triggered: bool) -> None:
         print(f"Zone {zone} changed to {triggered}")
 
+    @client.on_output_change
+    def on_output_change(output: int, state: bool) -> None:
+        print(f"Output {output} changed to {state}")
+
     @client.on_state_change
     def on_state_change(state: ArmingState, arming_mode: ArmingMode | None) -> None:
         print(f"Alarm state changed to {state} (mode: {arming_mode})")

--- a/nessclient/cli/server/output.py
+++ b/nessclient/cli/server/output.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from enum import Enum
+
+
+@dataclass
+class Output:
+    class State(Enum):
+        OFF = "OFF"
+        ON = "ON"
+
+    id: int
+    state: State

--- a/nessclient/cli/tui.py
+++ b/nessclient/cli/tui.py
@@ -153,6 +153,26 @@ async def interactive_ui(
                 )
                 y += 1
 
+            for i, output in enumerate(client.alarm.outputs, start=1):
+                if y >= zone_inner_h - 1:
+                    break
+                trig = output.triggered
+                if trig is None:
+                    status = "UNKNOWN"
+                    attr = curses.A_DIM | curses.color_pair(3)
+                else:
+                    if trig:
+                        status = "ON"
+                        attr = curses.A_NORMAL | curses.color_pair(1)
+                    else:
+                        status = "OFF"
+                        attr = curses.A_NORMAL | curses.color_pair(2)
+                out_line = f"O{i:02d}: {status}"
+                zone_win.addnstr(
+                    y, 2, out_line.ljust(zone_inner_w - 4), zone_inner_w - 4, attr
+                )
+                y += 1
+
             # Logs/messages pane
             logs_h = top_h - 1
             log_win = stdscr.derwin(logs_h, logs_w, 1, zones_w)

--- a/nessclient/client.py
+++ b/nessclient/client.py
@@ -253,6 +253,12 @@ class Client:
         self.alarm.on_zone_change(f)
         return f
 
+    def on_output_change(
+        self, f: Callable[[int, bool], None]
+    ) -> Callable[[int, bool], None]:
+        self.alarm.on_output_change(f)
+        return f
+
     def on_event_received(
         self, f: Callable[[BaseEvent], None]
     ) -> Callable[[BaseEvent], None]:


### PR DESCRIPTION
## Summary
- track output states in the core alarm model and expose an output change callback
- handle S15/S18 output commands in the fake alarm server and show outputs in the TUI
- surface output changes in the events client and display them alongside zones

## Testing
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae2e23ebc483318175118f7cf9b42b