### PR TITLE
Add auxiliary output support

### DIFF
--- a/examples/sending_commands.py
+++ b/examples/sending_commands.py
@@ -18,7 +18,7 @@ async def main() -> None:
         # Send disarm command via library abstraction
         await client.disarm("1234")
         # Send aux control command for output 2 via library abstraction
-        await client.aux(2)
+        await client.aux_output(2)
         # Send custom command
         # In this instance, we are sending a status update command to view
         # output status

--- a/nessclient/cli/events.py
+++ b/nessclient/cli/events.py
@@ -239,7 +239,7 @@ async def interactive_ui(
             input_win.addstr(0, 2, " Input ", curses.A_BOLD)
             legend = [
                 "Commands: a=arm_away h=arm_home d [code] u=update q=quit",
-                "o <n> to toggle outputs",
+                "o<n> or o <n> to toggle outputs",
                 "Arrow/PgUp/PgDn/Home/End to scroll messages",
             ]
             for i, line in enumerate(legend):
@@ -295,9 +295,9 @@ async def interactive_ui(
                             _add_log(logs, "TX", "Update")
                             await client.update()
                         elif lower.startswith("o"):
-                            parts = lower.split()
-                            if len(parts) >= 2 and parts[1].isdigit():
-                                output_id = int(parts[1])
+                            num_str = lower[1:].strip()
+                            if num_str.isdigit():
+                                output_id = int(num_str)
                                 if 1 <= output_id <= len(client.alarm.aux_outputs):
                                     current = client.alarm.aux_outputs[
                                         output_id - 1
@@ -312,7 +312,7 @@ async def interactive_ui(
                                 else:
                                     status_message = f"Invalid output: {output_id}"
                             else:
-                                status_message = "Usage: o <output>"
+                                status_message = "Usage: o<n> or o <n>"
                         else:
                             status_message = f"Unknown command: {cmd}"
                 elif ch in (curses.KEY_BACKSPACE, 127, 8):

--- a/nessclient/cli/server/alarm_server.py
+++ b/nessclient/cli/server/alarm_server.py
@@ -191,7 +191,8 @@ class AlarmServer:
         # Legend area
         legend_lines = [
             "Commands: a=away h=home n=night v=vac d=disarm t=trip s=sim on/off",
-            f"Toggle zone: type number then Enter (1-{len(self._alarm.zones)})    q=quit",
+            f"Toggle zone: number then Enter (1-{len(self._alarm.zones)})  "
+            f"Toggle output: o <n> (1-{len(self._alarm.aux_outputs)})  q=quit",
         ]
         for i, line in enumerate(legend_lines):
             if 1 + i >= win_height - 2:
@@ -309,6 +310,24 @@ class AlarmServer:
             return
         if lc in ("s off", "sim off", "simulate off"):
             self._toggle_simulation(False)
+            return
+        if lc.startswith("o"):
+            parts = lc.split()
+            output_id: int | None = None
+            if len(parts) == 2 and parts[1].isdigit():
+                output_id = int(parts[1])
+            if output_id is not None:
+                out = next(
+                    (o for o in self._alarm.aux_outputs if o.id == output_id), None
+                )
+                if out is not None:
+                    activate = out.state == AuxOutput.State.OFF
+                    self._alarm.update_aux_output(output_id, activate)
+                    self._set_status(f"Toggled output {output_id}")
+                else:
+                    self._set_status(f"Invalid output: {output_id}")
+            else:
+                self._set_status("Usage: o <output>")
             return
         if lc.isdigit():
             zone_id = int(lc)

--- a/nessclient/cli/server/alarm_server.py
+++ b/nessclient/cli/server/alarm_server.py
@@ -192,7 +192,7 @@ class AlarmServer:
         legend_lines = [
             "Commands: a=away h=home n=night v=vac d=disarm t=trip s=sim on/off",
             f"Toggle zone: number then Enter (1-{len(self._alarm.zones)})  "
-            f"Toggle output: o <n> (1-{len(self._alarm.aux_outputs)})  q=quit",
+            f"Toggle output: o<n> or o <n> (1-{len(self._alarm.aux_outputs)})  q=quit",
         ]
         for i, line in enumerate(legend_lines):
             if 1 + i >= win_height - 2:
@@ -312,10 +312,10 @@ class AlarmServer:
             self._toggle_simulation(False)
             return
         if lc.startswith("o"):
-            parts = lc.split()
             output_id: int | None = None
-            if len(parts) == 2 and parts[1].isdigit():
-                output_id = int(parts[1])
+            num_str = lc[1:].strip()
+            if num_str.isdigit():
+                output_id = int(num_str)
             if output_id is not None:
                 out = next(
                     (o for o in self._alarm.aux_outputs if o.id == output_id), None
@@ -327,7 +327,7 @@ class AlarmServer:
                 else:
                     self._set_status(f"Invalid output: {output_id}")
             else:
-                self._set_status("Usage: o <output>")
+                self._set_status("Usage: o<n> or o <n>")
             return
         if lc.isdigit():
             zone_id = int(lc)

--- a/nessclient/cli/server/aux_output.py
+++ b/nessclient/cli/server/aux_output.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+from enum import Enum
+
+
+@dataclass
+class AuxOutput:
+    class State(Enum):
+        OFF = "OFF"
+        ON = "ON"
+
+    id: int
+    state: State

--- a/nessclient/event.py
+++ b/nessclient/event.py
@@ -704,6 +704,19 @@ class AuxiliaryOutputsUpdate(StatusUpdate):
         )
         self.outputs = outputs
 
+    def encode(self) -> Packet:
+        data = "{:02x}{}".format(
+            self.request_id.value, pack_unsigned_short_data_enum(self.outputs)
+        )
+        return Packet(
+            address=self.address,
+            seq=0x00,
+            command=CommandType.USER_INTERFACE,
+            data=data,
+            timestamp=None,
+            is_user_interface_resp=True,
+        )
+
     @classmethod
     def decode(
         cls, packet: Packet, options: DecodeOptions | None = None

--- a/nessclient_tests/test_client.py
+++ b/nessclient_tests/test_client.py
@@ -61,30 +61,31 @@ async def test_panic(connection, client):
 
 
 @pytest.mark.asyncio
-async def test_aux_on(connection, client):
-    await client.aux(1, True)
+async def test_aux_output_on(connection, client):
+    await client.aux_output(1, True)
     assert connection.write.call_count == 1
     assert get_data(connection.write.call_args[0][0]) == b"11*"
 
 
 @pytest.mark.asyncio
-async def test_aux_off(connection, client):
-    await client.aux(1, False)
+async def test_aux_output_off(connection, client):
+    await client.aux_output(1, False)
     assert connection.write.call_count == 1
     assert get_data(connection.write.call_args[0][0]) == b"11#"
 
 
 @pytest.mark.asyncio
 async def test_update(connection, client: Client, alarm: Alarm):
-    # Update should send S00, S20 and S14
+    # Update should send S00, S20, S14 and S18
     await client.update()
-    assert connection.write.call_count == 3
+    assert connection.write.call_count == 4
     commands = {
         get_data(connection.write.call_args_list[0][0][0]),
         get_data(connection.write.call_args_list[1][0][0]),
         get_data(connection.write.call_args_list[2][0][0]),
+        get_data(connection.write.call_args_list[3][0][0]),
     }
-    assert commands == {b"S00", b"S20", b"S14"}
+    assert commands == {b"S00", b"S20", b"S14", b"S18"}
 
 
 @pytest.mark.asyncio

--- a/nessclient_tests/test_integration.py
+++ b/nessclient_tests/test_integration.py
@@ -99,7 +99,8 @@ async def test_update_emits_ascii_payloads(
     connection.write.assert_any_call(b"8300360S00E9\r\n")
     connection.write.assert_any_call(b"8300360S20E7\r\n")
     connection.write.assert_any_call(b"8300360S14E4\r\n")
-    assert connection.write.await_count == 3
+    connection.write.assert_any_call(b"8300360S18E0\r\n")
+    assert connection.write.await_count == 4
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- track and expose auxiliary outputs in the alarm and client
- display and control aux outputs in events TUI with `o` commands
- teach fake alarm server to process and report aux output commands
- factor server auxiliary output dataclass into its own module

## Testing
- `uv run ruff check .`
- `uv run mypy --strict nessclient`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aef8e6b5288331bde4958caf498826