### PR TITLE
Clarify static imports requirement in tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,5 +15,6 @@ This repository uses [uv](https://docs.astral.sh/uv/) for dependency management 
 
 ## Testing
 - Run the test suite with `uv run pytest`.
+- Test modules must use static imports; avoid importing within individual test cases.
 
 These commands should be executed and pass before committing any changes.


### PR DESCRIPTION
## Summary
- document that test modules must use static imports rather than importing within individual tests

## Testing
- `uv sync --dev --all-extras`
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run mypy --strict nessclient`
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b2d3d909808331ad8126caa6976907