### PR TITLE
Swap to regular assert as per PT009

### DIFF
--- a/nessclient_tests/test_event.py
+++ b/nessclient_tests/test_event.py
@@ -1,5 +1,6 @@
 import unittest
 from typing import cast
+import pytest
 
 from nessclient.event import (
     ZoneUpdate_1_16,
@@ -22,72 +23,77 @@ from nessclient.packet import Packet, CommandType
 class UtilsTestCase(unittest.TestCase):
     def test_pack_unsigned_short_data_enum(self):
         value = [ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_4]
-        self.assertEqual(
-            "0900",
-            pack_unsigned_short_data_enum(value),
-        )
+        assert "0900" == pack_unsigned_short_data_enum(value)
 
 
 class BaseEventTestCase(unittest.TestCase):
     def test_decode_system_status_event(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "000000")
         event = BaseEvent.decode(pkt)
-        self.assertTrue(isinstance(event, SystemStatusEvent))
+        assert isinstance(event, SystemStatusEvent)
 
     def test_decode_user_interface_event(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "000000")
         event = BaseEvent.decode(pkt)
-        self.assertTrue(isinstance(event, StatusUpdate))
+        assert isinstance(event, StatusUpdate)
 
     def test_decode_unknown_event(self):
         pkt = make_packet(cast(CommandType, 0x01), "000000")
-        self.assertRaises(ValueError, lambda: BaseEvent.decode(pkt))
+        with pytest.raises(
+            ValueError,
+            match=r"Unknown command: 1",
+        ):
+            BaseEvent.decode(pkt)
 
 
 class StatusUpdateTestCase(unittest.TestCase):
     def test_decode_zone_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "000000")
         event = StatusUpdate.decode(pkt)
-        self.assertTrue(isinstance(event, ZoneUpdate_1_16))
+        assert isinstance(event, ZoneUpdate_1_16)
 
     def test_decode_zone_17_32_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "200000")
         event = StatusUpdate.decode(pkt)
-        self.assertTrue(isinstance(event, ZoneUpdate_17_32))
+        assert isinstance(event, ZoneUpdate_17_32)
 
     def test_decode_misc_alarms_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "130000")
         event = StatusUpdate.decode(pkt)
-        self.assertTrue(isinstance(event, MiscellaneousAlarmsUpdate))
+        assert isinstance(event, MiscellaneousAlarmsUpdate)
 
     def test_decode_arming_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "140000")
         event = StatusUpdate.decode(pkt)
-        self.assertTrue(isinstance(event, ArmingUpdate))
+        assert isinstance(event, ArmingUpdate)
 
     def test_decode_outputs_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "150000")
         event = StatusUpdate.decode(pkt)
-        self.assertTrue(isinstance(event, OutputsUpdate))
+        assert isinstance(event, OutputsUpdate)
 
     def test_decode_view_state_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "16f000")
         event = StatusUpdate.decode(pkt)
-        self.assertTrue(isinstance(event, ViewStateUpdate))
+        assert isinstance(event, ViewStateUpdate)
 
     def test_decode_panel_version_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "170000")
         event = StatusUpdate.decode(pkt)
-        self.assertTrue(isinstance(event, PanelVersionUpdate))
+        assert isinstance(event, PanelVersionUpdate)
 
     def test_decode_auxiliary_outputs_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "180000")
         event = StatusUpdate.decode(pkt)
-        self.assertTrue(isinstance(event, AuxiliaryOutputsUpdate))
+        assert isinstance(event, AuxiliaryOutputsUpdate)
 
     def test_decode_unknown_update(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "550000")
-        self.assertRaises(ValueError, lambda: StatusUpdate.decode(pkt))
+        with pytest.raises(
+            ValueError,
+            match=r"85 is not a valid StatusUpdate.RequestID",
+        ):
+            StatusUpdate.decode(pkt)
 
 
 class ArmingUpdateTestCase(unittest.TestCase):
@@ -98,20 +104,17 @@ class ArmingUpdateTestCase(unittest.TestCase):
             address=0x00,
         )
         pkt = event.encode()
-        self.assertEqual(pkt.command, CommandType.USER_INTERFACE)
-        self.assertEqual(pkt.data, "140400")
-        self.assertTrue(pkt.is_user_interface_resp)
+        assert pkt.command == CommandType.USER_INTERFACE
+        assert pkt.data == "140400"
+        assert pkt.is_user_interface_resp
 
     def test_area1_armed(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "140500")
         event = ArmingUpdate.decode(pkt)
-        self.assertEqual(
-            event.status,
-            [
-                ArmingUpdate.ArmingStatus.AREA_1_ARMED,
-                ArmingUpdate.ArmingStatus.AREA_1_FULLY_ARMED,
-            ],
-        )
+        assert event.status == [
+            ArmingUpdate.ArmingStatus.AREA_1_ARMED,
+            ArmingUpdate.ArmingStatus.AREA_1_FULLY_ARMED,
+        ]
 
 
 class ZoneUpdate1To16TestCase(unittest.TestCase):
@@ -123,57 +126,56 @@ class ZoneUpdate1To16TestCase(unittest.TestCase):
             address=0x00,
         )
         pkt = event.encode()
-        self.assertEqual(pkt.command, CommandType.USER_INTERFACE)
-        self.assertEqual(pkt.data, "000500")
-        self.assertTrue(pkt.is_user_interface_resp)
+        assert pkt.command == CommandType.USER_INTERFACE
+        assert pkt.data == "000500"
+        assert pkt.is_user_interface_resp
 
     def test_zone_in_delay_no_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "030000")
         event = ZoneUpdate_1_16.decode(pkt)
-        self.assertEqual(event.request_id, ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_DELAY)
-        self.assertEqual(event.included_zones, [])
+        assert event.request_id == ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_DELAY
+        assert event.included_zones == []
 
     def test_zone_in_delay_with_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "030500")
         event = ZoneUpdate_1_16.decode(pkt)
-        self.assertEqual(event.request_id, ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_DELAY)
-        self.assertEqual(
-            event.included_zones,
-            [ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
-        )
+        assert event.request_id == ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_DELAY
+        assert event.included_zones == [
+            ZoneUpdate_1_16.Zone.ZONE_1,
+            ZoneUpdate_1_16.Zone.ZONE_3,
+        ]
 
     def test_zone_in_alarm_with_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "051400")
         event = ZoneUpdate_1_16.decode(pkt)
-        self.assertEqual(event.request_id, ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_ALARM)
-        self.assertEqual(
-            event.included_zones,
-            [ZoneUpdate_1_16.Zone.ZONE_3, ZoneUpdate_1_16.Zone.ZONE_5],
-        )
+        assert event.request_id == ZoneUpdate_1_16.RequestID.ZONE_1_16_IN_ALARM
+        assert event.included_zones == [
+            ZoneUpdate_1_16.Zone.ZONE_3,
+            ZoneUpdate_1_16.Zone.ZONE_5,
+        ]
 
     def test_zone_detector_low_battery_with_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "110500")
         event = ZoneUpdate_1_16.decode(pkt)
-        self.assertEqual(
-            event.request_id,
-            ZoneUpdate_1_16.RequestID.ZONE_1_16_DETECTOR_LOW_BATTERY,
+        assert (
+            event.request_id == ZoneUpdate_1_16.RequestID.ZONE_1_16_DETECTOR_LOW_BATTERY
         )
-        self.assertEqual(
-            event.included_zones,
-            [ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
-        )
+        assert event.included_zones == [
+            ZoneUpdate_1_16.Zone.ZONE_1,
+            ZoneUpdate_1_16.Zone.ZONE_3,
+        ]
 
     def test_zone_1_16_excluded_plus_auto(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "190500")
         event = ZoneUpdate_1_16.decode(pkt)
-        self.assertEqual(
-            event.request_id,
-            ZoneUpdate_1_16.RequestID.ZONE_1_16_EXCLUDED_PLUS_AUTO_EXCLUDED,
+        assert (
+            event.request_id
+            == ZoneUpdate_1_16.RequestID.ZONE_1_16_EXCLUDED_PLUS_AUTO_EXCLUDED
         )
-        self.assertEqual(
-            event.included_zones,
-            [ZoneUpdate_1_16.Zone.ZONE_1, ZoneUpdate_1_16.Zone.ZONE_3],
-        )
+        assert event.included_zones == [
+            ZoneUpdate_1_16.Zone.ZONE_1,
+            ZoneUpdate_1_16.Zone.ZONE_3,
+        ]
 
 
 class ZoneUpdate17To32TestCase(unittest.TestCase):
@@ -188,380 +190,372 @@ class ZoneUpdate17To32TestCase(unittest.TestCase):
             address=0x00,
         )
         pkt = event.encode()
-        self.assertEqual(pkt.command, CommandType.USER_INTERFACE)
-        self.assertEqual(pkt.data, "200500")
-        self.assertTrue(pkt.is_user_interface_resp)
+        assert pkt.command == CommandType.USER_INTERFACE
+        assert pkt.data == "200500"
+        assert pkt.is_user_interface_resp
 
     def test_zone_in_delay_no_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "230000")
         event = ZoneUpdate_17_32.decode(pkt)
-        self.assertEqual(event.request_id, ZoneUpdate_17_32.RequestID.ZONE_17_32_IN_DELAY)
-        self.assertEqual(event.included_zones, [])
+        assert event.request_id == ZoneUpdate_17_32.RequestID.ZONE_17_32_IN_DELAY
+        assert event.included_zones == []
 
     def test_zone_in_delay_with_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "230500")
         event = ZoneUpdate_17_32.decode(pkt)
-        self.assertEqual(event.request_id, ZoneUpdate_17_32.RequestID.ZONE_17_32_IN_DELAY)
-        self.assertEqual(
-            event.included_zones,
-            [ZoneUpdate_17_32.Zone.ZONE_17, ZoneUpdate_17_32.Zone.ZONE_19],
-        )
+        assert event.request_id == ZoneUpdate_17_32.RequestID.ZONE_17_32_IN_DELAY
+        assert event.included_zones == [
+            ZoneUpdate_17_32.Zone.ZONE_17,
+            ZoneUpdate_17_32.Zone.ZONE_19,
+        ]
 
     def test_zone_detector_low_battery_with_zones(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "310500")
         event = ZoneUpdate_17_32.decode(pkt)
-        self.assertEqual(
-            event.request_id,
-            ZoneUpdate_17_32.RequestID.ZONE_17_32_DETECTOR_LOW_BATTERY,
+        assert (
+            event.request_id
+            == ZoneUpdate_17_32.RequestID.ZONE_17_32_DETECTOR_LOW_BATTERY
         )
-        self.assertEqual(
-            event.included_zones,
-            [ZoneUpdate_17_32.Zone.ZONE_17, ZoneUpdate_17_32.Zone.ZONE_19],
-        )
+        assert event.included_zones == [
+            ZoneUpdate_17_32.Zone.ZONE_17,
+            ZoneUpdate_17_32.Zone.ZONE_19,
+        ]
 
     def test_zone_excluded_plus_auto(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "330500")
         event = ZoneUpdate_17_32.decode(pkt)
-        self.assertEqual(
-            event.request_id,
-            ZoneUpdate_17_32.RequestID.ZONE_17_32_EXCLUDED_PLUS_AUTO_EXCLUDED,
+        assert (
+            event.request_id
+            == ZoneUpdate_17_32.RequestID.ZONE_17_32_EXCLUDED_PLUS_AUTO_EXCLUDED
         )
-        self.assertEqual(
-            event.included_zones,
-            [ZoneUpdate_17_32.Zone.ZONE_17, ZoneUpdate_17_32.Zone.ZONE_19],
-        )
+        assert event.included_zones == [
+            ZoneUpdate_17_32.Zone.ZONE_17,
+            ZoneUpdate_17_32.Zone.ZONE_19,
+        ]
 
 
 class ViewStateUpdateTestCase(unittest.TestCase):
     def test_normal_state(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "16f000")
         event = ViewStateUpdate.decode(pkt)
-        self.assertEqual(event.state, ViewStateUpdate.State.NORMAL)
+        assert event.state == ViewStateUpdate.State.NORMAL
 
 
 class OutputsUpdateTestCase(unittest.TestCase):
     def test_panic_outputs(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "157100")
         event = OutputsUpdate.decode(pkt)
-        self.assertEqual(
-            event.outputs,
-            [
-                OutputsUpdate.OutputType.SIREN_LOUD,
-                OutputsUpdate.OutputType.STROBE,
-                OutputsUpdate.OutputType.RESET,
-                OutputsUpdate.OutputType.SONALART,
-            ],
-        )
+        assert event.outputs == [
+            OutputsUpdate.OutputType.SIREN_LOUD,
+            OutputsUpdate.OutputType.STROBE,
+            OutputsUpdate.OutputType.RESET,
+            OutputsUpdate.OutputType.SONALART,
+        ]
 
 
 class MiscellaneousAlarmsUpdateTestCase(unittest.TestCase):
     def test_misc_alarms_install_end(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "131000")
         event = MiscellaneousAlarmsUpdate.decode(pkt)
-        self.assertEqual(
-            event.included_alarms, [MiscellaneousAlarmsUpdate.AlarmType.INSTALL_END]
-        )
+        assert event.included_alarms == [
+            MiscellaneousAlarmsUpdate.AlarmType.INSTALL_END
+        ]
 
     def test_misc_alarms_panic(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "130200")
         event = MiscellaneousAlarmsUpdate.decode(pkt)
-        self.assertEqual(
-            event.included_alarms, [MiscellaneousAlarmsUpdate.AlarmType.PANIC]
-        )
+        assert event.included_alarms == [MiscellaneousAlarmsUpdate.AlarmType.PANIC]
 
     def test_misc_alarms_multi(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "131500")
         event = MiscellaneousAlarmsUpdate.decode(pkt)
-        self.assertEqual(
-            event.included_alarms,
-            [
-                MiscellaneousAlarmsUpdate.AlarmType.DURESS,
-                MiscellaneousAlarmsUpdate.AlarmType.MEDICAL,
-                MiscellaneousAlarmsUpdate.AlarmType.INSTALL_END,
-            ],
-        )
+        assert event.included_alarms == [
+            MiscellaneousAlarmsUpdate.AlarmType.DURESS,
+            MiscellaneousAlarmsUpdate.AlarmType.MEDICAL,
+            MiscellaneousAlarmsUpdate.AlarmType.INSTALL_END,
+        ]
 
 
 class SystemStatusEventTestCase(unittest.TestCase):
     def test_exit_delay_end(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "230001")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 0)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.EXIT_DELAY_END)
+        assert event.area == 1
+        assert event.zone == 0
+        assert event.type == SystemStatusEvent.EventType.EXIT_DELAY_END
 
     def test_zone_sealed_with_zone_5(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "010500")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.SEALED)
+        assert event.area == 0
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.SEALED
 
     def test_zone_unsealed_with_zone_15(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "001500")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 15)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
+        assert event.area == 0
+        assert event.zone == 15
+        assert event.type == SystemStatusEvent.EventType.UNSEALED
 
     def test_zone_unsealed_with_zone_16(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "001600")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 16)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
+        assert event.area == 0
+        assert event.zone == 16
+        assert event.type == SystemStatusEvent.EventType.UNSEALED
 
     def test_zone_sealed_with_zone_17_in_area_1(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "011701")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 17)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.SEALED)
+        assert event.area == 1
+        assert event.zone == 17
+        assert event.type == SystemStatusEvent.EventType.SEALED
 
     def test_zone_unsealed_with_zone_17_in_area_1(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "001701")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 17)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
+        assert event.area == 1
+        assert event.zone == 17
+        assert event.type == SystemStatusEvent.EventType.UNSEALED
 
     def test_zone_sealed_with_zone_17(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "011700")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 17)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.SEALED)
+        assert event.area == 0
+        assert event.zone == 17
+        assert event.type == SystemStatusEvent.EventType.SEALED
 
     def test_zone_unsealed_with_zone_17(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "001700")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 17)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
+        assert event.area == 0
+        assert event.zone == 17
+        assert event.type == SystemStatusEvent.EventType.UNSEALED
 
     def test_zone_sealed_with_zone_32(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "013200")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 32)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.SEALED)
+        assert event.area == 0
+        assert event.zone == 32
+        assert event.type == SystemStatusEvent.EventType.SEALED
 
     def test_zone_unsealed_with_zone_32(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "003200")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 32)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.UNSEALED)
+        assert event.area == 0
+        assert event.zone == 32
+        assert event.type == SystemStatusEvent.EventType.UNSEALED
 
     def test_zone_alarm_with_zone_5_area_1(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "020501")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.ALARM)
+        assert event.area == 1
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.ALARM
 
     def test_tamper_unsealed_with_zone_5_radio(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "080591")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0x91)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.TAMPER_UNSEALED)
+        assert event.area == 0x91
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.TAMPER_UNSEALED
 
     def test_power_failure(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "100000")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 0)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.POWER_FAILURE)
+        assert event.area == 0
+        assert event.zone == 0
+        assert event.type == SystemStatusEvent.EventType.POWER_FAILURE
 
     def test_entry_delay_start(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "200501")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.ENTRY_DELAY_START)
+        assert event.area == 1
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.ENTRY_DELAY_START
 
     def test_output_on(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "310100")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 1)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.OUTPUT_ON)
+        assert event.area == 0
+        assert event.zone == 1
+        assert event.type == SystemStatusEvent.EventType.OUTPUT_ON
 
     def test_alarm_restore_with_zone_5_area_1(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "030501")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.ALARM_RESTORE)
+        assert event.area == 1
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.ALARM_RESTORE
 
     def test_tamper_normal_with_zone_5_radio(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "090591")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0x91)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.TAMPER_NORMAL)
+        assert event.area == 0x91
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.TAMPER_NORMAL
 
     def test_power_normal(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "110000")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 0)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.POWER_NORMAL)
+        assert event.area == 0
+        assert event.zone == 0
+        assert event.type == SystemStatusEvent.EventType.POWER_NORMAL
 
     def test_battery_failure(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "120000")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 0)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.BATTERY_FAILURE)
+        assert event.area == 0
+        assert event.zone == 0
+        assert event.type == SystemStatusEvent.EventType.BATTERY_FAILURE
 
     def test_battery_normal(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "130000")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 0)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.BATTERY_NORMAL)
+        assert event.area == 0
+        assert event.zone == 0
+        assert event.type == SystemStatusEvent.EventType.BATTERY_NORMAL
 
     def test_report_failure(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "140000")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 0)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.REPORT_FAILURE)
+        assert event.area == 0
+        assert event.zone == 0
+        assert event.type == SystemStatusEvent.EventType.REPORT_FAILURE
 
     def test_report_normal(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "150000")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 0)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.REPORT_NORMAL)
+        assert event.area == 0
+        assert event.zone == 0
+        assert event.type == SystemStatusEvent.EventType.REPORT_NORMAL
 
     def test_supervision_failure_zone_5(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "160500")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.SUPERVISION_FAILURE)
+        assert event.area == 0
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.SUPERVISION_FAILURE
 
     def test_supervision_normal_zone_5(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "170500")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.SUPERVISION_NORMAL)
+        assert event.area == 0
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.SUPERVISION_NORMAL
 
     def test_real_time_clock(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "190000")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 0)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.REAL_TIME_CLOCK)
+        assert event.area == 0
+        assert event.zone == 0
+        assert event.type == SystemStatusEvent.EventType.REAL_TIME_CLOCK
 
     def test_entry_delay_end(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "210501")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.ENTRY_DELAY_END)
+        assert event.area == 1
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.ENTRY_DELAY_END
 
     def test_exit_delay_start(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "220501")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.EXIT_DELAY_START)
+        assert event.area == 1
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.EXIT_DELAY_START
 
     def test_armed_away(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "240101")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 1)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMED_AWAY)
+        assert event.area == 1
+        assert event.zone == 1
+        assert event.type == SystemStatusEvent.EventType.ARMED_AWAY
 
     def test_disarmed(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "2f0101")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 1)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.DISARMED)
+        assert event.area == 1
+        assert event.zone == 1
+        assert event.type == SystemStatusEvent.EventType.DISARMED
 
     def test_arming_delayed(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "300101")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 1)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMING_DELAYED)
+        assert event.area == 1
+        assert event.zone == 1
+        assert event.type == SystemStatusEvent.EventType.ARMING_DELAYED
 
     def test_output_off(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "320100")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 1)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.OUTPUT_OFF)
+        assert event.area == 0
+        assert event.zone == 1
+        assert event.type == SystemStatusEvent.EventType.OUTPUT_OFF
 
     def test_manual_exclude_with_zone_5_area_1(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "040501")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.MANUAL_EXCLUDE)
+        assert event.area == 1
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.MANUAL_EXCLUDE
 
     def test_manual_include_with_zone_5_area_1(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "050501")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.MANUAL_INCLUDE)
+        assert event.area == 1
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.MANUAL_INCLUDE
 
     def test_auto_exclude_with_zone_5_area_1(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "060501")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.AUTO_EXCLUDE)
+        assert event.area == 1
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.AUTO_EXCLUDE
 
     def test_auto_include_with_zone_5_area_1(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "070501")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 1)
-        self.assertEqual(event.zone, 5)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.AUTO_INCLUDE)
+        assert event.area == 1
+        assert event.zone == 5
+        assert event.type == SystemStatusEvent.EventType.AUTO_INCLUDE
 
     def test_armed_home(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "250103")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 3)
-        self.assertEqual(event.zone, 1)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMED_HOME)
+        assert event.area == 3
+        assert event.zone == 1
+        assert event.type == SystemStatusEvent.EventType.ARMED_HOME
 
     def test_armed_day(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "260004")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 4)
-        self.assertEqual(event.zone, 0)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMED_DAY)
+        assert event.area == 4
+        assert event.zone == 0
+        assert event.type == SystemStatusEvent.EventType.ARMED_DAY
 
     def test_armed_night(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "270000")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 0)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMED_NIGHT)
+        assert event.area == 0
+        assert event.zone == 0
+        assert event.type == SystemStatusEvent.EventType.ARMED_NIGHT
 
     def test_armed_vacation(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "280000")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 0)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMED_VACATION)
+        assert event.area == 0
+        assert event.zone == 0
+        assert event.type == SystemStatusEvent.EventType.ARMED_VACATION
 
     def test_armed_highest(self):
         pkt = make_packet(CommandType.SYSTEM_STATUS, "2e0000")
         event = SystemStatusEvent.decode(pkt)
-        self.assertEqual(event.area, 0)
-        self.assertEqual(event.zone, 0)
-        self.assertEqual(event.type, SystemStatusEvent.EventType.ARMED_HIGHEST)
+        assert event.area == 0
+        assert event.zone == 0
+        assert event.type == SystemStatusEvent.EventType.ARMED_HIGHEST
 
 
 Rev16DecodeOptions = DecodeOptions(
@@ -576,58 +570,60 @@ class PanelVersionUpdateTestCase(unittest.TestCase):
     def test_inferred_d16x_model(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "170000")
         event = PanelVersionUpdate.decode(pkt)
-        self.assertEqual(event.model, PanelVersionUpdate.Model.D16X)
+        assert event.model == PanelVersionUpdate.Model.D16X
 
     def test_inferred_d16x_cel_4g_model_via_fallback(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "171500")
         event = PanelVersionUpdate.decode(pkt)
-        self.assertEqual(event.model, PanelVersionUpdate.Model.D16X_CEL_4G)
+        assert event.model == PanelVersionUpdate.Model.D16X_CEL_4G
 
     def test_rev16_d8x_model(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "170000")
         event = PanelVersionUpdate.decode(pkt, Rev16DecodeOptions)
-        self.assertEqual(event.model, PanelVersionUpdate.Model.D8X)
+        assert event.model == PanelVersionUpdate.Model.D8X
 
     def test_rev16_d8xcel_3g_model(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "170400")
         event = PanelVersionUpdate.decode(pkt, Rev16DecodeOptions)
-        self.assertEqual(event.model, PanelVersionUpdate.Model.D8X_CEL_3G)
+        assert event.model == PanelVersionUpdate.Model.D8X_CEL_3G
 
     def test_rev16_d16x_model(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "171000")
         event = PanelVersionUpdate.decode(pkt, Rev16DecodeOptions)
-        self.assertEqual(event.model, PanelVersionUpdate.Model.D16X)
+        assert event.model == PanelVersionUpdate.Model.D16X
 
     def test_rev16_d16xcel_3g_model(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "171400")
         event = PanelVersionUpdate.decode(pkt, Rev16DecodeOptions)
-        self.assertEqual(event.model, PanelVersionUpdate.Model.D16X_CEL_3G)
+        assert event.model == PanelVersionUpdate.Model.D16X_CEL_3G
 
     def test_rev16_d16xcel_4g_model(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "171500")
         event = PanelVersionUpdate.decode(pkt, Rev16DecodeOptions)
-        self.assertEqual(event.model, PanelVersionUpdate.Model.D16X_CEL_4G)
+        assert event.model == PanelVersionUpdate.Model.D16X_CEL_4G
 
     def test_legacy_d16x_model(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "170000")
         event = PanelVersionUpdate.decode(pkt, LegacyDecodeOptions)
-        self.assertEqual(event.model, PanelVersionUpdate.Model.D16X)
+        assert event.model == PanelVersionUpdate.Model.D16X
 
     def test_legacy_d16x_cel_3g_model_1(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "170400")
         event = PanelVersionUpdate.decode(pkt, LegacyDecodeOptions)
-        self.assertEqual(event.model, PanelVersionUpdate.Model.D16X_CEL_3G)
+        assert event.model == PanelVersionUpdate.Model.D16X_CEL_3G
 
     def test_legacy_d16x_cel_3g_model_2(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "171400")
         event = PanelVersionUpdate.decode(pkt, LegacyDecodeOptions)
-        self.assertEqual(event.model, PanelVersionUpdate.Model.D16X_CEL_3G)
+        assert event.model == PanelVersionUpdate.Model.D16X_CEL_3G
 
     def test_legacy_unhandled_model(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "171300")
-        self.assertRaises(
-            KeyError, lambda: PanelVersionUpdate.decode(pkt, LegacyDecodeOptions)
-        )
+        with pytest.raises(
+            KeyError,
+            match=r"19",
+        ):
+            PanelVersionUpdate.decode(pkt, LegacyDecodeOptions)
 
     def test_sw_version(self):
         cases = [
@@ -642,42 +638,33 @@ class PanelVersionUpdateTestCase(unittest.TestCase):
             with self.subTest(data=data):
                 pkt = make_packet(CommandType.USER_INTERFACE, data)
                 event = PanelVersionUpdate.decode(pkt)
-                self.assertEqual(event.major_version, major)
-                self.assertEqual(event.minor_version, minor)
-                self.assertEqual(event.version, version)
+                assert event.major_version == major
+                assert event.minor_version == minor
+                assert event.version == version
 
 
 class AuxiliaryOutputsUpdateTestCase(unittest.TestCase):
     def test_aux_output_1(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "170001")
         event = AuxiliaryOutputsUpdate.decode(pkt)
-        self.assertEqual(
-            event.outputs,
-            [
-                AuxiliaryOutputsUpdate.OutputType.AUX_1,
-            ],
-        )
+        assert event.outputs == [
+            AuxiliaryOutputsUpdate.OutputType.AUX_1,
+        ]
 
     def test_aux_output_4(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "170008")
         event = AuxiliaryOutputsUpdate.decode(pkt)
-        self.assertEqual(
-            event.outputs,
-            [
-                AuxiliaryOutputsUpdate.OutputType.AUX_4,
-            ],
-        )
+        assert event.outputs == [
+            AuxiliaryOutputsUpdate.OutputType.AUX_4,
+        ]
 
     def test_aux_output_multi(self):
         pkt = make_packet(CommandType.USER_INTERFACE, "170088")
         event = AuxiliaryOutputsUpdate.decode(pkt)
-        self.assertEqual(
-            event.outputs,
-            [
-                AuxiliaryOutputsUpdate.OutputType.AUX_4,
-                AuxiliaryOutputsUpdate.OutputType.AUX_8,
-            ],
-        )
+        assert event.outputs == [
+            AuxiliaryOutputsUpdate.OutputType.AUX_4,
+            AuxiliaryOutputsUpdate.OutputType.AUX_8,
+        ]
 
 
 def make_packet(command: CommandType, data: str):

--- a/nessclient_tests/test_packet.py
+++ b/nessclient_tests/test_packet.py
@@ -22,7 +22,7 @@ class PacketTestCase(unittest.TestCase):
 
         for case in cases:
             pkt = Packet.decode(case)
-            self.assertEqual(case, pkt.encode())
+            assert case == pkt.encode()
 
     def test_decode(self):
         with open(fixture_path("sample_output.txt")) as f:
@@ -33,61 +33,59 @@ class PacketTestCase(unittest.TestCase):
 
     def test_user_interface_packet_decode(self):
         pkt = Packet.decode("8300c6012345678912EE7")
-        self.assertEqual(pkt.start, 0x83)
-        self.assertEqual(pkt.address, 0x00)
-        self.assertEqual(pkt.length, 12)
-        self.assertEqual(pkt.seq, 0x00)
-        self.assertEqual(pkt.command, CommandType.USER_INTERFACE)
-        self.assertEqual(pkt.data, "12345678912E")
-        self.assertIsNone(pkt.timestamp)
-        self.assertEqual(pkt.checksum, 0xE7)
+        assert pkt.start == 0x83
+        assert pkt.address == 0x00
+        assert pkt.length == 12
+        assert pkt.seq == 0x00
+        assert pkt.command == CommandType.USER_INTERFACE
+        assert pkt.data == "12345678912E"
+        assert pkt.timestamp is None
+        assert pkt.checksum == 0xE7
 
     def test_system_status_packet_decode(self):
         pkt = Packet.decode("8700036100070018092118370974")
-        self.assertEqual(pkt.start, 0x87)
-        self.assertEqual(pkt.address, 0x00)
-        self.assertEqual(pkt.length, 3)
-        self.assertEqual(pkt.seq, 0x00)
-        self.assertEqual(pkt.command, CommandType.SYSTEM_STATUS)
-        self.assertEqual(pkt.data, "000700")
-        self.assertEqual(
-            pkt.timestamp,
-            datetime.datetime(year=2018, month=9, day=21, hour=18, minute=37, second=9),
+        assert pkt.start == 0x87
+        assert pkt.address == 0x00
+        assert pkt.length == 3
+        assert pkt.seq == 0x00
+        assert pkt.command == CommandType.SYSTEM_STATUS
+        assert pkt.data == "000700"
+        assert pkt.timestamp == datetime.datetime(
+            year=2018, month=9, day=21, hour=18, minute=37, second=9
         )
-        # self.assertEqual(pkt.checksum, 0x74)
+        # assert pkt.checksum == 0x74
 
     def test_decode_with_address_and_time(self):
         pkt = Packet.decode("8709036101050018122709413536")
-        self.assertEqual(pkt.address, 0x09)
-        self.assertEqual(pkt.length, 3)
-        self.assertEqual(pkt.seq, 0x00)
-        self.assertEqual(pkt.command, CommandType.SYSTEM_STATUS)
-        self.assertEqual(pkt.data, "010500")
-        self.assertEqual(
-            pkt.timestamp,
-            datetime.datetime(year=2018, month=12, day=27, hour=9, minute=41, second=35),
+        assert pkt.address == 0x09
+        assert pkt.length == 3
+        assert pkt.seq == 0x00
+        assert pkt.command == CommandType.SYSTEM_STATUS
+        assert pkt.data == "010500"
+        assert pkt.timestamp == datetime.datetime(
+            year=2018, month=12, day=27, hour=9, minute=41, second=35
         )
-        self.assertFalse(pkt.is_user_interface_resp)
+        assert not pkt.is_user_interface_resp
 
     def test_decode_without_address(self):
         pkt = Packet.decode("820361230001f6")
-        self.assertIsNone(pkt.address)
-        self.assertEqual(pkt.length, 3)
-        self.assertEqual(pkt.seq, 0x00)
-        self.assertEqual(pkt.command, CommandType.SYSTEM_STATUS)
-        self.assertEqual(pkt.data, "230001")
-        self.assertIsNone(pkt.timestamp)
-        self.assertFalse(pkt.is_user_interface_resp)
+        assert pkt.address is None
+        assert pkt.length == 3
+        assert pkt.seq == 0x00
+        assert pkt.command == CommandType.SYSTEM_STATUS
+        assert pkt.data == "230001"
+        assert pkt.timestamp is None
+        assert not pkt.is_user_interface_resp
 
     def test_decode_with_address(self):
         pkt = Packet.decode("820003600000001b")
-        self.assertEqual(pkt.address, 0x00)
-        self.assertEqual(pkt.length, 3)
-        self.assertEqual(pkt.seq, 0x00)
-        self.assertEqual(pkt.command, CommandType.USER_INTERFACE)
-        self.assertEqual(pkt.data, "000000")
-        self.assertIsNone(pkt.timestamp)
-        self.assertTrue(pkt.is_user_interface_resp)
+        assert pkt.address == 0x00
+        assert pkt.length == 3
+        assert pkt.seq == 0x00
+        assert pkt.command == CommandType.USER_INTERFACE
+        assert pkt.data == "000000"
+        assert pkt.timestamp is None
+        assert pkt.is_user_interface_resp
 
     def test_encode_decode1(self):
         pkt = Packet(
@@ -97,8 +95,8 @@ class PacketTestCase(unittest.TestCase):
             data="A1234E",
             timestamp=None,
         )
-        self.assertEqual(pkt.length, 6)
-        self.assertEqual(pkt.encode(), "8300660A1234E49")
+        assert pkt.length == 6
+        assert pkt.encode() == "8300660A1234E49"
 
     def test_encode_cecode2(self):
         pkt = Packet(
@@ -110,47 +108,45 @@ class PacketTestCase(unittest.TestCase):
                 year=2018, month=5, day=10, hour=15, minute=32, second=55
             ),
         )
-        self.assertEqual(pkt.length, 3)
-        self.assertEqual(pkt.encode(), "87000360000100180510153255E3")
+        assert pkt.length == 3
+        assert pkt.encode() == "87000360000100180510153255E3"
 
     def test_decode_status_update_response(self):
         """
         82 00 03 60 070000 14
         """
         pkt = Packet.decode("8200036007000014")
-        self.assertEqual(pkt.start, 0x82)
-        self.assertEqual(pkt.address, 0x00)
-        self.assertEqual(pkt.length, 3)
-        self.assertEqual(pkt.seq, 0x00)
-        self.assertEqual(pkt.command, CommandType.USER_INTERFACE)
-        self.assertEqual(pkt.data, "070000")
-        self.assertIsNone(pkt.timestamp)
-        # self.assertEqual(pkt.checksum, 0x14)
+        assert pkt.start == 0x82
+        assert pkt.address == 0x00
+        assert pkt.length == 3
+        assert pkt.seq == 0x00
+        assert pkt.command == CommandType.USER_INTERFACE
+        assert pkt.data == "070000"
+        assert pkt.timestamp is None
+        # assert pkt.checksum == 0x14
 
     def test_bad_timestamp(self):
         pkt = Packet.decode("8700036100070019022517600057")
-        self.assertEqual(pkt.start, 0x87)
-        self.assertEqual(pkt.address, 0x00)
-        self.assertEqual(pkt.length, 3)
-        self.assertEqual(pkt.seq, 0x00)
-        self.assertEqual(pkt.command, CommandType.SYSTEM_STATUS)
-        self.assertEqual(pkt.data, "000700")
-        self.assertEqual(
-            pkt.timestamp,
-            datetime.datetime(year=2019, month=2, day=25, hour=18, minute=0, second=0),
+        assert pkt.start == 0x87
+        assert pkt.address == 0x00
+        assert pkt.length == 3
+        assert pkt.seq == 0x00
+        assert pkt.command == CommandType.SYSTEM_STATUS
+        assert pkt.data == "000700"
+        assert pkt.timestamp == datetime.datetime(
+            year=2019, month=2, day=25, hour=18, minute=0, second=0
         )
 
     def test_decode_zone_16(self):
         pkt = Packet.decode("8700036100160019022823032274")
-        self.assertEqual(pkt.start, 0x87)
-        self.assertEqual(pkt.address, 0x00)
-        self.assertEqual(pkt.length, 3)
-        self.assertEqual(pkt.seq, 0x00)
-        self.assertEqual(pkt.command, CommandType.SYSTEM_STATUS)
-        self.assertEqual(pkt.data, "001600")
-        self.assertEqual(
-            pkt.timestamp,
-            datetime.datetime(year=2019, month=2, day=28, hour=23, minute=3, second=22),
+        assert pkt.start == 0x87
+        assert pkt.address == 0x00
+        assert pkt.length == 3
+        assert pkt.seq == 0x00
+        assert pkt.command == CommandType.SYSTEM_STATUS
+        assert pkt.data == "001600"
+        assert pkt.timestamp == datetime.datetime(
+            year=2019, month=2, day=28, hour=23, minute=3, second=22
         )
 
     def test_decode_update(self):
@@ -162,37 +158,37 @@ class PacketTestCase(unittest.TestCase):
     def test_decode_status_update_response_zone_17_32_none(self):
         # Zone 17-32 Input Unsealed (ID 0x20), no zones set
         pkt = Packet.decode("82000360200000ff")
-        self.assertEqual(pkt.start, 0x82)
-        self.assertEqual(pkt.address, 0x00)
-        self.assertEqual(pkt.length, 3)
-        self.assertEqual(pkt.seq, 0x00)
-        self.assertEqual(pkt.command, CommandType.USER_INTERFACE)
-        self.assertEqual(pkt.data, "200000")
-        self.assertIsNone(pkt.timestamp)
-        self.assertTrue(pkt.is_user_interface_resp)
+        assert pkt.start == 0x82
+        assert pkt.address == 0x00
+        assert pkt.length == 3
+        assert pkt.seq == 0x00
+        assert pkt.command == CommandType.USER_INTERFACE
+        assert pkt.data == "200000"
+        assert pkt.timestamp is None
+        assert pkt.is_user_interface_resp
 
     def test_decode_status_update_response_zone_17_32_in_alarm_zone17(self):
         # Zone 17-32 In Alarm (ID 0x25), Zone 17 set
         pkt = Packet.decode("82000360250100aa")
-        self.assertEqual(pkt.data, "250100")
-        self.assertTrue(pkt.is_user_interface_resp)
+        assert pkt.data == "250100"
+        assert pkt.is_user_interface_resp
 
     def test_decode_status_update_response_zone_23_unsealed_example(self):
         # From FORM 5 examples in the spec (address 0x07)
         # Example: Zone 23 unseal (ID 0x20, data 0x4000)
         pkt = Packet.decode("8207036020400013")
-        self.assertEqual(pkt.start, 0x82)
-        self.assertEqual(pkt.address, 0x07)
-        self.assertEqual(pkt.length, 3)
-        self.assertEqual(pkt.seq, 0x00)
-        self.assertEqual(pkt.command, CommandType.USER_INTERFACE)
-        self.assertEqual(pkt.data, "204000")
-        self.assertTrue(pkt.is_user_interface_resp)
+        assert pkt.start == 0x82
+        assert pkt.address == 0x07
+        assert pkt.length == 3
+        assert pkt.seq == 0x00
+        assert pkt.command == CommandType.USER_INTERFACE
+        assert pkt.data == "204000"
+        assert pkt.is_user_interface_resp
 
     def test_decode_status_update_response_zone_23_24_unsealed_example(self):
         # From FORM 5 examples in the spec (address 0x07)
         # Example: Zones 23 and 24 unseal (ID 0x20, data 0xC000)
         pkt = Packet.decode("8207036020c00054")
-        self.assertEqual(pkt.address, 0x07)
-        self.assertEqual(pkt.data, "20c000")
-        self.assertTrue(pkt.is_user_interface_resp)
+        assert pkt.address == 0x07
+        assert pkt.data == "20c000"
+        assert pkt.is_user_interface_resp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,4 +53,5 @@ line-length = 90
 extend-exclude = ["venv", "virtualenv", "docs"]
 
 [tool.ruff.lint]
+extend-select = ["PT009"]
 ignore = ["E261", "E203"]


### PR DESCRIPTION
Picked up by RUFF
Regular assert statements are preferred over unittest's assertion methods.

(Moved PR to master branch)